### PR TITLE
[#326] Filter empty obfuscation strings

### DIFF
--- a/src/electron/src/components/DataExportWindowActivityTracker.vue
+++ b/src/electron/src/components/DataExportWindowActivityTracker.vue
@@ -85,7 +85,7 @@ const emitObfuscateSampleData = async () => {
         <div class="mb-2 mt-1 flex justify-center">
           <label class="form-control w-full">
             <input
-              v-model="obfuscationTermsInput"
+              v-model.trim="obfuscationTermsInput"
               type="text"
               placeholder="Enter, terms, here, ..."
               class="input input-bordered w-full text-sm"

--- a/src/electron/src/views/DataExportView.vue
+++ b/src/electron/src/views/DataExportView.vue
@@ -94,10 +94,13 @@ async function handleWindowActivityExportConfigChanged(newSelectedOption: DataEx
 }
 
 async function handleObfuscationTermsChanged(newObfuscationTerms: string) {
-  if (!newObfuscationTerms) {
+  if (!newObfuscationTerms || newObfuscationTerms.trim().length === 0) {
     obfuscationTermsInput.value = [];
   } else {
-    obfuscationTermsInput.value = newObfuscationTerms.split(',').map((s: string) => s.trim());
+    obfuscationTermsInput.value = newObfuscationTerms
+      .split(',')
+      .map((s: string) => s.trim())
+      .filter((s: string) => s.length > 0);
   }
 }
 


### PR DESCRIPTION
This fixes the "empty" strings that would redact everything.
I did not add a minimum now, might be confusing if user tries to do one thing but the app does another without stating so - can still do if you want though.