### PR TITLE
Sync main to dev

### DIFF
--- a/src/electron/.gitignore
+++ b/src/electron/.gitignore
@@ -18,5 +18,3 @@ release
 *.njsproj
 *.sln
 *.sw?
-
-external/dyn

--- a/src/electron/electron/ipc/IpcHandler.ts
+++ b/src/electron/electron/ipc/IpcHandler.ts
@@ -77,13 +77,6 @@ export class IpcHandler {
       triggerPermissionCheckScreenRecording: this.triggerPermissionCheckScreenRecording
     };
 
-    if (studyConfig.trackers.taskTracker?.enabled) {
-      const { actions } = await import('@external/main/ipc/IpcHandler'); 
-      Object.keys(actions).forEach((action: string) => {
-        this.actions[action] = actions[action];
-      });
-    } 
-
     Object.keys(this.actions).forEach((action: string): void => {
       LOG.info(`ipcMain.handle setup: ${action}`);
       ipcMain.handle(action, async (_event: IpcMainInvokeEvent, ...args): Promise<any> => {

--- a/src/electron/electron/main/services/DatabaseService.ts
+++ b/src/electron/electron/main/services/DatabaseService.ts
@@ -8,7 +8,6 @@ import { ExperienceSamplingResponseEntity } from '../entities/ExperienceSampling
 import { UserInputEntity } from '../entities/UserInputEntity';
 import { Settings } from '../entities/Settings';
 import { UsageDataEntity } from '../entities/UsageDataEntity';
-import config from '../../../shared/study.config';
 import { WorkDayEntity } from '../entities/WorkDayEntity'
 
 const LOG = getMainLogger('DatabaseService');
@@ -36,13 +35,6 @@ export class DatabaseService {
       WindowActivityEntity,
       WorkDayEntity
     ]
-
-    if (config.trackers.taskTracker?.enabled) {
-      const { PersonalTaskEntity } = await import('@external/main/entities/PersonalTaskEntity');
-      const { TaskActivityEntity } = await import('@external/main/entities/TaskActivityEntity');
-      entities.push(PersonalTaskEntity);
-      entities.push(TaskActivityEntity);
-    } 
     
     let options: DataSourceOptions = {
       type: 'better-sqlite3',

--- a/src/electron/electron/main/services/WindowService.ts
+++ b/src/electron/electron/main/services/WindowService.ts
@@ -384,14 +384,6 @@ export class WindowService {
         click: () => this.createExperienceSamplingWindow(true)
       },
       {
-        label: 'Open Task Planning',
-        visible: !!studyConfig.trackers.taskTracker?.enabled,
-        click: async () => {
-          const { createPlanningViewWindow } = await import('@external/main/services/WindowService')
-          createPlanningViewWindow(true)
-        }
-      },
-      {
         label: 'Open Settings',
         click: () => this.createSettingsWindow()
       },

--- a/src/electron/electron/main/services/WorkScheduleService.ts
+++ b/src/electron/electron/main/services/WorkScheduleService.ts
@@ -21,13 +21,7 @@ export class WorkScheduleService {
 
   private schedulingService: any;
 
-  async init() {
-    if (studyConfig.trackers.taskTracker?.enabled) {
-      const { SchedulingService } = await import('@external/main/services/SchedulingService'); 
-      const schedule = await this.getWorkSchedule()
-      this.schedulingService = new SchedulingService(schedule);
-    }
-  }
+  async init() { }
   
   public async setWorkSchedule(schedule: WorkHoursDto): Promise<void> {
     // clear existing work schedule

--- a/src/electron/electron/preload/index.ts
+++ b/src/electron/electron/preload/index.ts
@@ -1,37 +1,7 @@
-// OTODO: how to deal with this??? - 2024-11-25
-// import { ElectronAPI } from '@electron-toolkit/preload';
 import { ipcRenderer, contextBridge } from 'electron';
-
-// Custom APIs for renderer
-const api: Api = {
-  onLoadTaskbarTasks: (callback) => {
-    ipcRenderer.on('loadTaskbarTasks', callback);
-  },
-  onRemindToTrackTime: (callback) =>
-    ipcRenderer.on('remindToTrackTime', (_event, reason) => callback(reason)),
-  onTaskWidgetWindowFocused: (callback) => ipcRenderer.on('taskWidgetWindowFocused', callback),
-  isMacOS: (): boolean => process.platform === 'darwin'
-};
-
-interface Api {
-  onLoadTaskbarTasks: (cb) => void;
-  onRemindToTrackTime: (cb) => void;
-  onTaskWidgetWindowFocused: (cb) => void;
-  isMacOS: () => boolean;
-}
-
-declare global {
-  interface Window {
-    ipcRenderer: Record<string, any>;
-    api: Api;
-  }
-}
 
 contextBridge.exposeInMainWorld('ipcRenderer', withPrototype(ipcRenderer));
 window.ipcRenderer = ipcRenderer;
-
-contextBridge.exposeInMainWorld('api', withPrototype(api));
-window.api = api;
 
 // `exposeInMainWorld` can't detect attributes and methods of `prototype`, manually patching it.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/electron/external/README.md
+++ b/src/electron/external/README.md
@@ -1,6 +1,0 @@
-## External Components
-External components which are not included in the base version of PA are dynamically copied in this directory at build time.
-- If external components exist (currently, the only one is `PA.SelfReflection`), they are copied into `dyn` at build time.
-- If external components are  missing, its `stub` is copied into `dyn` instead, and PA builds without the additional logic/functionality.
-
-For more information on the import resolution, have a look at at [vite config](../../vite.config.ts) and watch out for `@external` and `@externalVue` imports throughout the codebase.

--- a/src/electron/external/stub/main/entities/PersonalTaskEntity.ts
+++ b/src/electron/external/stub/main/entities/PersonalTaskEntity.ts
@@ -1,1 +1,0 @@
-export class PersonalTaskEntity {}

--- a/src/electron/external/stub/main/entities/TaskActivityEntity.ts
+++ b/src/electron/external/stub/main/entities/TaskActivityEntity.ts
@@ -1,1 +1,0 @@
-export class TaskActivityEntity {}

--- a/src/electron/external/stub/main/ipc/IpcHandler.ts
+++ b/src/electron/external/stub/main/ipc/IpcHandler.ts
@@ -1,1 +1,0 @@
-export const actions = {}

--- a/src/electron/external/stub/main/services/SchedulingService.ts
+++ b/src/electron/external/stub/main/services/SchedulingService.ts
@@ -1,1 +1,0 @@
-export class SchedulingService  {}

--- a/src/electron/external/stub/main/services/TaskService.ts
+++ b/src/electron/external/stub/main/services/TaskService.ts
@@ -1,1 +1,0 @@
-export function createPlanningViewWindow() {}

--- a/src/electron/external/stub/main/services/WindowService.ts
+++ b/src/electron/external/stub/main/services/WindowService.ts
@@ -1,1 +1,0 @@
-export class WindowService {}

--- a/src/electron/package-lock.json
+++ b/src/electron/package-lock.json
@@ -23,7 +23,6 @@
       },
       "devDependencies": {
         "@electron/notarize": "^2.3.0",
-        "@rollup/plugin-alias": "^5.1.1",
         "@rushstack/eslint-patch": "^1.7.2",
         "@tailwindcss/typography": "^0.5.10",
         "@types/better-sqlite3": "^7.6.9",
@@ -43,7 +42,6 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-vue": "^9.21.1",
-        "fs-extra": "^11.2.0",
         "less": "^4.2.0",
         "postcss": "^8.4.33",
         "prettier": "^3.2.5",
@@ -2279,23 +2277,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
-      }
-    },
-    "node_modules/@rollup/plugin-alias": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.1.tgz",
-      "integrity": "sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -6623,20 +6604,6 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
-    },
-    "node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",

--- a/src/electron/package.json
+++ b/src/electron/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@electron/notarize": "^2.3.0",
-    "@rollup/plugin-alias": "^5.1.1",
     "@rushstack/eslint-patch": "^1.7.2",
     "@tailwindcss/typography": "^0.5.10",
     "@types/better-sqlite3": "^7.6.9",
@@ -47,7 +46,6 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-vue": "^9.21.1",
-    "fs-extra": "^11.2.0",
     "less": "^4.2.0",
     "postcss": "^8.4.33",
     "prettier": "^3.2.5",

--- a/src/electron/src/router/index.ts
+++ b/src/electron/src/router/index.ts
@@ -9,16 +9,6 @@ const router: Router = createRouter({
       component: () => import('../views/ExperienceSamplingView.vue')
     },
     {
-      path: '/planning',
-      name: 'Planning',
-      component: () => import('@externalVue/renderer/views/PlanningView.vue')
-    },
-    {
-      path: '/taskbar-view',
-      name: 'Taskbar View',
-      component: () => import('@externalVue/renderer/views/TaskBarView.vue')
-    },
-    {
       path: '/onboarding',
       name: 'Onboarding',
       component: () => import('../views/OnboardingView.vue'),

--- a/src/electron/tailwind.config.js
+++ b/src/electron/tailwind.config.js
@@ -2,7 +2,7 @@
 import colors from 'tailwindcss/colors';
 
 module.exports = {
-  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}', './external/dyn/**/*.{vue,js,ts,jsx,tsx}'],
+  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
   plugins: [require('@tailwindcss/typography'), require('daisyui')],
   theme: {
     extend: {

--- a/src/electron/tsconfig.node.json
+++ b/src/electron/tsconfig.node.json
@@ -6,10 +6,7 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
-    "paths": {
-      "@external/*": ["external/dyn/*"]
-    }
+    "baseUrl": "."
   },
-  "include": ["vite.config.ts", "package.json", "electron", "external/dyn/**/*"]
+  "include": ["vite.config.ts", "package.json", "electron"]
 }

--- a/src/electron/vite.config.ts
+++ b/src/electron/vite.config.ts
@@ -1,42 +1,19 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import electron from 'vite-plugin-electron/simple';
-import alias from '@rollup/plugin-alias'
 import pkg from './package.json';
-import fse from 'fs-extra';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => {
   fs.rmSync('dist-electron', { recursive: true, force: true });
-  
-  // Path to the task/goal setting component (optional; PA.SelfReflection)
-  // PA.SelfReflection should be in the same folder as PersonalAnalytics  
-  const externalDir = path.resolve(__dirname, '../../../PA.SelfReflection/src'); 
-  const backupStubDir = path.resolve(__dirname, 'external/stub');
-  const dynDir = path.resolve(__dirname, 'external/dyn')
-  if (fs.existsSync(dynDir)) {
-    fs.rmSync(dynDir, { recursive: true, force: true });
-  }
-  if (fs.existsSync(externalDir)) {
-    console.log(`Copying PA.SelfReflection component from ${externalDir} to ${dynDir}`);
-    fse.copySync(externalDir, dynDir);
-  } else {
-    console.log(`Copying stub files from ${backupStubDir} to ${dynDir}`);
-    fse.copySync(backupStubDir, dynDir);
-  }
-    
+      
   const isServe = command === 'serve';
   const isBuild = command === 'build';
   const sourcemap = isServe || !!process.env.VSCODE_DEBUG;
 
   return {
-    plugins: [
-      // this works for the renderer files, but does not work for the main files
-      alias({
-        entries: [ { find: '@externalVue', replacement: dynDir} ]
-      }),
+    plugins: [   
       vue(),
       electron({
         main: {
@@ -48,11 +25,6 @@ export default defineConfig(({ command }) => {
               minify: isBuild,
               outDir: 'dist-electron/main',
               rollupOptions: {
-                plugins:  
-                  // for the main files...
-                  alias({
-                    entries: [ { find: '@external', replacement: dynDir } ]
-                }),
                 // Some third-party Node.js libraries may not be built correctly by Vite, especially `C/C++` addons,
                 // we can use `external` to exclude them to ensure they work correctly.
                 // Others need to put them in `dependencies` to ensure they are collected into `app.asar` after the app is built.


### PR DESCRIPTION
* Merge Main to Dev (after adding Windows Code Signing) (#374)

* [#350] attempting windows code signing

* [#350] updating electron-builder

* [#350] trying newer version of electron builder

* [#350] fixing notarize

* [#350] fixing macos notarization attempt 2

* [#350] testing auto-update for code-signed win version

* [#350] updated electron-updater

* [#350] testing auto-update on windows

* [#350] added explicit publisherName for Windows, updated signing docu

* [#350] version bump to trigger build

* [#350] trying updater without verification

* [#350] another try

* [#350] attempting to fix macOS updater

* [#350] trigger update to 0.0.32

* [#350] trying to fix macos build

* [#350] trying to fix macOS build

* [#350] trying to fix update code signature verification on windows

* [#350] trying to fix update code signature verification on windows (v0.0.35)

* [#350] trying to fix update code signature verification on windows

* [#350] removing publisherName tag again (no longer supported)

* [#373] disabled verify update code signature on windows

---------



* fixed GH secrets info

* 366 clarify app is running (#375) and windows code signing (#350)

This comprises:
- refining context menu items
- showing PA is running in tasktray
- windows code signing 
- shows onboarding screen upon *manual* app launch
- bugfix related to macOS auto-updater (intel vs apple silicon feed url)

* [#366] test changes in release (0.0.37)

* fixed links in readme

* [#376] adjust file logging to only log 'silly' on debug (#377)

* [#376] adjust file logging to only log 'silly' on debug

* [#376] moved is-dev check to other file (suggested by @royru)

* testing something in CI release (0.0.38)

* added link to GH access token

* fixed link to GH access token

* Settings / Work Hours / Data Export Warning / Days Participated (#379)

* initial commit

* fixes colorpicker in PA.SelfReflection

* basic workschedule backend

* work hours front-end within `Settings` page

* `config.displayDaysParticipated` implemented

* show warning when data export win is closed before export completion

* remove README

* remove vscode setting

* tray menu improvements

* exclude experience sampling entries in for "days participated" if disabled

* `taskTracker` optional

* fixing log outputs

* update research.md

* fix data export warning dialog on Windows

* fix visibility of "Open Task Planning"

* fixing `dataExportWindow` getting destroyed prematurely

* documentation for "work hours" feature

* small design/text updates

* updating package-lock.json (#388)

* reverted changes of the airbar stub

* revert formatting changes

---------