### PR TITLE
enforce dark mode

### DIFF
--- a/src/electron/tailwind.config.js
+++ b/src/electron/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-import colors from 'tailwindcss/colors'
+import colors from 'tailwindcss/colors';
 
 module.exports = {
   content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
@@ -22,4 +22,4 @@ module.exports = {
       variants: ['active', 'focus']
     }
   ]
-}
+};

--- a/src/electron/tailwind.config.js
+++ b/src/electron/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-import colors from 'tailwindcss/colors';
+import colors from 'tailwindcss/colors'
 
 module.exports = {
   content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
@@ -11,6 +11,9 @@ module.exports = {
       }
     }
   },
+  daisyui: {
+    themes: ['dark']
+  },
   // needed for the dynamic classes
   safelist: [
     {
@@ -19,4 +22,4 @@ module.exports = {
       variants: ['active', 'focus']
     }
   ]
-};
+}


### PR DESCRIPTION
enforces dark mode even when a user uses light mode.

Exception: The experience sampling window remains white because it is hardcoded this way.