### PR TITLE
[#463] Remove ambiguous characters from generation of participant ID

### DIFF
--- a/src/electron/electron/main/services/utils/helpers.ts
+++ b/src/electron/electron/main/services/utils/helpers.ts
@@ -17,7 +17,7 @@ export function generateAlphaNumericString(length: number = 0): string {
     throw new Error('Length must be greater than 0');
   }
 
-  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  const characters = 'ABCDEFGHJKLMNPQRSTUVWXYZ123456789';
   let result = '';
   for (let i = 0; i < length; i++) {
     result += characters.charAt(Math.floor(Math.random() * characters.length));

--- a/src/electron/electron/main/services/utils/helpers.ts
+++ b/src/electron/electron/main/services/utils/helpers.ts
@@ -17,7 +17,7 @@ export function generateAlphaNumericString(length: number = 0): string {
     throw new Error('Length must be greater than 0');
   }
 
-  const characters = 'ABCDEFGHJKLMNPQRSTUVWXYZ123456789';
+  const characters = 'ABCDEFGHJKLMNPQRSTUVWXYZ123456789'; // removed 0, O, I and l from options to avoid participant IDs that are ambiguous 
   let result = '';
   for (let i = 0; i < length; i++) {
     result += characters.charAt(Math.floor(Math.random() * characters.length));


### PR DESCRIPTION
- Removed the ambiguous characters (`0`, `O`, `I` and `l`) from the character set

Closes #463 