### PR TITLE
[#380] Add logging for experience sampling

### DIFF
--- a/src/electron/electron/ipc/IpcHandler.ts
+++ b/src/electron/electron/ipc/IpcHandler.ts
@@ -115,7 +115,8 @@ export class IpcHandler {
     responseOptions: string | null,
     scale: number | null,
     response?: string,
-    skipped: boolean = false
+    skipped: boolean = false,
+    trigger: 'manual' | 'auto' = 'auto'
   ) {
     await this.experienceSamplingService.createExperienceSample(
       promptedAt,
@@ -124,7 +125,8 @@ export class IpcHandler {
       responseOptions,
       scale,
       response,
-      skipped
+      skipped,
+      trigger
     );
   }
 

--- a/src/electron/electron/main/entities/ExperienceSamplingResponseEntity.ts
+++ b/src/electron/electron/main/entities/ExperienceSamplingResponseEntity.ts
@@ -24,4 +24,7 @@ export class ExperienceSamplingResponseEntity extends BaseTrackedEntity {
 
   @Column('boolean', { default: false, nullable: false })
   skipped: boolean;
+
+  @Column('text', { default: 'auto' })
+  trigger: 'manual' | 'auto';
 }

--- a/src/electron/electron/main/entities/ExperienceSamplingResponseEntity.ts
+++ b/src/electron/electron/main/entities/ExperienceSamplingResponseEntity.ts
@@ -25,6 +25,6 @@ export class ExperienceSamplingResponseEntity extends BaseTrackedEntity {
   @Column('boolean', { default: false, nullable: false })
   skipped: boolean;
 
-  @Column('text', { default: 'auto' })
+  @Column('text', { default: 'auto', nullable: false })
   trigger: 'manual' | 'auto';
 }

--- a/src/electron/electron/main/services/ExperienceSamplingService.ts
+++ b/src/electron/electron/main/services/ExperienceSamplingService.ts
@@ -13,10 +13,11 @@ export class ExperienceSamplingService {
     responseOptions: string | null,
     scale: number | null,
     response?: string,
-    skipped: boolean
+    skipped: boolean,
+    trigger: 'manual' | 'auto' = 'auto'
   ): Promise<void> {
     LOG.debug(
-      `createExperienceSample: promptedAt=${promptedAt}, question=${question}, response=${response}, skipped=${skipped}`
+      `createExperienceSample: promptedAt=${promptedAt}, question=${question}, response=${response}, skipped=${skipped}, trigger=${trigger}`
     );
     await ExperienceSamplingResponseEntity.save({
       question,
@@ -25,7 +26,8 @@ export class ExperienceSamplingService {
       scale,
       response,
       promptedAt,
-      skipped
+      skipped,
+      trigger
     });
   }
 
@@ -45,6 +47,7 @@ export class ExperienceSamplingService {
       response: response.response,
       promptedAt: response.promptedAt,
       skipped: response.skipped,
+      trigger: response.trigger,
       createdAt: response.createdAt,
       updatedAt: response.updatedAt,
       deletedAt: response.deletedAt

--- a/src/electron/electron/main/services/WindowService.ts
+++ b/src/electron/electron/main/services/WindowService.ts
@@ -87,13 +87,15 @@ export class WindowService {
       }
     })
 
+    const trigger = isManuallyTriggered ? 'manual' : 'auto';
     if (process.env.VITE_DEV_SERVER_URL) {
       await this.experienceSamplingWindow.loadURL(
-        process.env.VITE_DEV_SERVER_URL + '#experience-sampling'
+        process.env.VITE_DEV_SERVER_URL + `?trigger=${trigger}#experience-sampling`
       )
     } else {
       await this.experienceSamplingWindow.loadFile(path.join(process.env.DIST, 'index.html'), {
-        hash: 'experience-sampling'
+        hash: 'experience-sampling',
+        query: { trigger }
       })
     }
 

--- a/src/electron/shared/dto/ExperienceSamplingDto.ts
+++ b/src/electron/shared/dto/ExperienceSamplingDto.ts
@@ -8,6 +8,7 @@ export default interface ExperienceSamplingDto {
   scale: number | null;
   response: string | null;
   skipped: boolean;
+  trigger: 'manual' | 'auto';
   promptedAt: Date;
   createdAt: Date;
   updatedAt: Date;

--- a/src/electron/src/utils/Commands.ts
+++ b/src/electron/src/utils/Commands.ts
@@ -16,7 +16,8 @@ type Commands = {
     responseOptions: string | null,
     scale?: number | null,
     response?: string,
-    skipped?: boolean
+    skipped?: boolean,
+    trigger?: 'manual' | 'auto'
   ) => Promise<void>;
   resizeExperienceSamplingWindow: (height: number) => void;
   closeExperienceSamplingWindow: (skippedExperienceSampling: boolean) => void;

--- a/src/electron/src/views/ExperienceSamplingView.vue
+++ b/src/electron/src/views/ExperienceSamplingView.vue
@@ -25,6 +25,7 @@ const language =
     (navigator.language || (navigator.languages && navigator.languages[0]))) ||
   'en';
 
+const trigger: 'manual' | 'auto' = new URLSearchParams(window.location.search).get('trigger') === 'manual' ? 'manual' : 'auto';
 const promptedAt = new Date();
 const promptedAtString = new Intl.DateTimeFormat(language, {
   hour: '2-digit',
@@ -164,7 +165,9 @@ async function createExperienceSample(answer?: number) {
         selectedQuestion.answerType,
         buildResponseOptionsSnapshot(),
         selectedQuestion.answerType === 'LikertScale' ? selectedQuestion.scale : null,
-        buildResponseValue(answer)
+        buildResponseValue(answer),
+        false,
+        trigger
       ),
       new Promise((resolve) => setTimeout(resolve, 150))
     ]);
@@ -190,7 +193,8 @@ async function skipExperienceSample() {
         buildResponseOptionsSnapshot(),
         selectedQuestion.answerType === 'LikertScale' ? selectedQuestion.scale : null,
         undefined,
-        true
+        true,
+        trigger
       ),
       new Promise((resolve) => setTimeout(resolve, 150))
     ]);


### PR DESCRIPTION
# Changes
- Adds a `trigger` column (`'manual'` | `'auto'`) to the `experience_sampling_responses` table
- `manual` = opened via tray context menu, `auto` = opened via scheduler
- Passed from WindowService → frontend (URL query param) → IPC → DB
- No migration needed (`synchronize: true`), existing rows default to `'auto'`

Closes #380 