### PR TITLE
Align Likert Buttons

### DIFF
--- a/src/electron/src/styles/tailwind-apply.css
+++ b/src/electron/src/styles/tailwind-apply.css
@@ -21,7 +21,7 @@
 }
 
 .experience-sampling-notification .sample-answer {
-  @apply mx-1 flex h-8 w-8 cursor-pointer items-center rounded-md border border-gray-200 dark:border-gray-600 bg-gray-100 dark:bg-gray-700 text-center align-middle text-gray-500 dark:text-gray-300 transition-all hover:bg-gray-700 hover:text-white dark:hover:bg-gray-500;
+  @apply flex flex-1 cursor-pointer items-center justify-center rounded-md border border-gray-300 bg-gray-100 py-1 text-center text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-70 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600;
 }
 
 /* used in DataExportView.vue */

--- a/src/electron/src/views/ExperienceSamplingView.vue
+++ b/src/electron/src/views/ExperienceSamplingView.vue
@@ -218,20 +218,22 @@ async function skipExperienceSample() {
         <div class="flex flex-1 flex-col">
           <p class="prompt">{{ selectedQuestion.question }}</p>
 
-          <div v-if="selectedQuestion.answerType === 'LikertScale'" class="-mx-1 mt-2 flex flex-row justify-between">
-            <div
+          <div v-if="selectedQuestion.answerType === 'LikertScale'" class="mt-2 flex flex-row gap-1.5">
+            <button
               v-for="value in scale"
               :key="value"
+              type="button"
               class="sample-answer"
-              @click="!isSubmitting && createExperienceSample(value)"
+              :disabled="isSubmitting"
+              @click="createExperienceSample(value)"
             >
-              <span v-if="!(isSubmitting && submitMode === 'answer')" class="mx-auto flex font-medium">
+              <span v-if="!(isSubmitting && submitMode === 'answer')">
                 {{ value }}
               </span>
-              <span v-else class="mx-auto flex font-medium">
+              <span v-else>
                 <span class="loading loading-spinner loading-xs" />
               </span>
-            </div>
+            </button>
           </div>
 
           <div v-if="selectedQuestion.answerType === 'LikertScale'" class="mt-1 flex flex-row text-sm text-gray-400 dark:text-gray-500">


### PR DESCRIPTION
Align the design of the buttons for Likert questions to visually look like the ones from the start-of-day and end-of-day questionnaires.

<img width="568" height="230" alt="Screenshot 2026-04-26 at 22 24 34" src="https://github.com/user-attachments/assets/8d27b3b6-2832-431f-8b25-818440d8a0e5" />
<img width="568" height="250" alt="Screenshot 2026-04-26 at 22 24 42" src="https://github.com/user-attachments/assets/805efd97-b3e2-49d8-8cf6-545639295e72" />
