### PR TITLE
[#386] Fix clean install onboarding startup screen

### DIFF
--- a/src/electron/electron/main/index.ts
+++ b/src/electron/electron/main/index.ts
@@ -137,15 +137,18 @@ app.whenReady().then(async () => {
     }
 
     const settings: Settings = await Settings.findOneBy({ onlyOneEntityShouldExist: 1 });
+    const onboardingShown = Boolean(settings.onboardingShown);
+    const studyAndTrackersStartedShown = Boolean(settings.studyAndTrackersStartedShown);
     const isAutoLaunch = app.getLoginItemSettings().wasOpenedAtLogin || process.argv.includes('--hidden');
+    const macOSHasRequiredPermissions = macOSHasRequiredTrackerPermissions();
 
     // show onboarding window (if never shown or macOS permissions are missing)
     if (
-      settings.onboardingShown === false ||
-      !macOSHasAccessibilityAndScreenRecordingPermission()
+      !onboardingShown ||
+      !macOSHasRequiredPermissions
     ) {
       LOG.debug(
-        `Onboarding shown: ${settings.onboardingShown}, hasAccessibilityAndScreenRecordingPermission: ${macOSHasAccessibilityAndScreenRecordingPermission()}, creating onboarding window...`
+        `Onboarding shown: ${settings.onboardingShown}, hasRequiredMacOSPermissions: ${macOSHasRequiredPermissions}, creating onboarding window...`
       );
       await windowService.createOnboardingWindow();
       settings.onboardingShown = true;
@@ -154,8 +157,8 @@ app.whenReady().then(async () => {
     // show PA running page when it was not shown before (on macOS) OR if it was manually started
     } else if (
       (is.macOS &&
-      settings.onboardingShown === true &&
-      settings.studyAndTrackersStartedShown === false) ||
+      onboardingShown &&
+      !studyAndTrackersStartedShown) ||
       (! isAutoLaunch)
     ) {
       await windowService.createOnboardingWindow('study-trackers-started');
@@ -163,9 +166,9 @@ app.whenReady().then(async () => {
       await settings.save();
     }
 
-    if (!is.macOS || macOSHasAccessibilityAndScreenRecordingPermission()) {
+    if (macOSHasRequiredPermissions) {
       LOG.debug(
-        `Onboarding shown: ${settings.onboardingShown}, hasAccessibilityAndScreenRecordingPermission: ${macOSHasAccessibilityAndScreenRecordingPermission()}, starting all trackers...`
+        `Onboarding shown: ${settings.onboardingShown}, hasRequiredMacOSPermissions: ${macOSHasRequiredPermissions}, starting all trackers...`
       );
       await trackers.startAllTrackers();
       LOG.info(`Trackers started: ${trackers.getRunningTrackerNames().join(', ')}`);
@@ -236,13 +239,23 @@ app.on('before-quit', async (event): Promise<void> => {
 // Don't quit when all windows are closed
 app.on('window-all-closed', () => {});
 
-function macOSHasAccessibilityAndScreenRecordingPermission(): boolean {
+function macOSHasRequiredTrackerPermissions(): boolean {
   if (!is.macOS) {
     return true;
   }
 
-  return (
-    systemPreferences.isTrustedAccessibilityClient(false) &&
-    systemPreferences.getMediaAccessStatus('screen') === 'granted'
-  );
+  const windowActivityTrackerEnabled = studyConfig.trackers.windowActivityTracker.enabled;
+  const requiresAccessibilityPermission =
+    studyConfig.trackers.userInputTracker.enabled ||
+    (windowActivityTrackerEnabled && studyConfig.trackers.windowActivityTracker.trackUrls);
+  const requiresScreenRecordingPermission =
+    windowActivityTrackerEnabled && studyConfig.trackers.windowActivityTracker.trackWindowTitles;
+
+  const hasAccessibilityPermission =
+    !requiresAccessibilityPermission || systemPreferences.isTrustedAccessibilityClient(false);
+  const hasScreenRecordingPermission =
+    !requiresScreenRecordingPermission ||
+    systemPreferences.getMediaAccessStatus('screen') === 'granted';
+
+  return hasAccessibilityPermission && hasScreenRecordingPermission;
 }

--- a/src/electron/src/views/OnboardingView.vue
+++ b/src/electron/src/views/OnboardingView.vue
@@ -4,7 +4,7 @@ import { computed, onMounted, ref } from 'vue';
 import StudyInfoDto from '../../shared/dto/StudyInfoDto';
 import typedIpcRenderer from '../utils/typedIpcRenderer';
 import StudyInfo from '../components/StudyInfo.vue';
-import { LocationQueryValue, useRoute } from 'vue-router';
+import { useRoute } from 'vue-router';
 import studyConfig from '../../shared/study.config';
 import Switch from '../components/Switch.vue';
 import WorkHoursRow from '../components/WorkHoursRow.vue';
@@ -30,8 +30,8 @@ const isAccessibilityPermissionLoading = ref(false);
 const isScreenRecordingPermissionLoading = ref(false);
 
 const route = useRoute();
-const isMacOS: string | null | LocationQueryValue[] = route.query.isMacOS;
-const goToStep: string | null | LocationQueryValue[] = route.query.goToStep;
+const isMacOS = route.query.isMacOS === 'true';
+const goToStep = typeof route.query.goToStep === 'string' ? route.query.goToStep : undefined;
 
 const shouldShowActiveTimesStep = computed(() => {
   const es = studyConfig.trackers.experienceSamplingTracker;
@@ -40,7 +40,7 @@ const shouldShowActiveTimesStep = computed(() => {
 
 const availableSteps = ['welcome'];
 
-if (isMacOS === 'true' && requiresAnyPermission) {
+if (isMacOS && requiresAnyPermission) {
   availableSteps.push('data-collection');
 }
 
@@ -48,7 +48,7 @@ if (shouldShowActiveTimesStep.value) {
   availableSteps.push('active-times');
 }
 
-if (isMacOS === 'false') {
+if (!isMacOS) {
   availableSteps.push('study-trackers-started');
 }
 


### PR DESCRIPTION
## Summary

- Fix clean-install onboarding startup so the full onboarding opens instead of the final "PersonalAnalytics is running" page
- Normalise persisted onboarding flags before branching on startup state
- Make macOS permission gating respect only permissions required by the study config

Closes #386