### PR TITLE
[#514] Add activity breakdown pie chart to Retrospection

### DIFF
--- a/src/electron/src/views/RetrospectionView.vue
+++ b/src/electron/src/views/RetrospectionView.vue
@@ -1,54 +1,146 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
-import { Activity, ActivitySessions, ChartDataPoint, DataPointType, TimeActive } from '../utils/retrospection/types'
-import { ACTIVITY_LABELS, getTailwindClassFromActivity } from '../utils/retrospection/utils'
-import StackedBarChart from '../components/StackedBarChart.vue'
+import { computed, onMounted, ref, type CSSProperties } from 'vue';
+import {
+  Activity,
+  Color,
+  DataPointType,
+  type ActivitySessions,
+  type ChartDataPoint,
+  type PieChartDataPoint,
+  type TimeActive
+} from '../utils/retrospection/types';
+import {
+  ACTIVITY_LABELS,
+  getActivityGroupFromActivityName,
+  getTailwindClassFromActivity
+} from '../utils/retrospection/utils';
+import StackedBarChart from '../components/StackedBarChart.vue';
 
-// @ts-ignore
-const typedIpcRenderer = window.ipcRenderer
-const isLoading = ref(false)
-const selectedDay = ref(new Date())
-const allWindowActivities = ref<ActivitySessions[]>([])
-const chartDataWindowActivities = ref<ChartDataPoint[]>()
-const longestTimeActive = ref<TimeActive | undefined>(undefined)
-const topApps = ref<ActivitySessions[] | undefined>(undefined)
-const topActivities = ref<ActivitySessions[]>([])
+const typedIpcRenderer = window.ipcRenderer;
+const isLoading = ref(false);
+const selectedDay = ref(new Date());
+const allWindowActivities = ref<ActivitySessions[]>([]);
+const chartDataWindowActivities = ref<ChartDataPoint[]>();
+const longestTimeActive = ref<TimeActive | undefined>(undefined);
+const topApps = ref<ActivitySessions[] | undefined>(undefined);
+const topActivities = ref<ActivitySessions[]>([]);
+const ACTIVITY_BREAKDOWN_COVERAGE = 0.9;
+
+interface ActivityBreakdownDataPoint extends PieChartDataPoint {
+  percentage: number;
+}
 
 const earliestUserComputerActivity = computed((): number => {
-  return chartDataWindowActivities.value?.reduce((acc, activity) => {
-    if (activity.start.getTime() < acc) {
-      return activity.start.getTime()
-    }
-    return acc
-  }, Number.MAX_SAFE_INTEGER) ?? Number.MAX_SAFE_INTEGER
-})
+  return (
+    chartDataWindowActivities.value?.reduce((acc, activity) => {
+      if (activity.start.getTime() < acc) {
+        return activity.start.getTime();
+      }
+      return acc;
+    }, Number.MAX_SAFE_INTEGER) ?? Number.MAX_SAFE_INTEGER
+  );
+});
 
 const latestUserComputerActivity = computed((): number => {
-  return chartDataWindowActivities.value?.reduce((acc, activity) => {
-    if (!activity.end) {
-      return Date.now()
+  return (
+    chartDataWindowActivities.value?.reduce((acc, activity) => {
+      if (!activity.end) {
+        return Date.now();
+      }
+      if (activity.end.getTime() > acc) {
+        return activity.end.getTime();
+      }
+      return acc;
+    }, 0) ?? 0
+  );
+});
+
+const activityBreakdownTotalMs = computed((): number => {
+  return (
+    allWindowActivities.value?.reduce((total, activitySession) => {
+      return total + activitySession.totalDurationMs;
+    }, 0) ?? 0
+  );
+});
+
+const activityBreakdownData = computed((): ActivityBreakdownDataPoint[] => {
+  const totalDurationMs = activityBreakdownTotalMs.value;
+  if (!totalDurationMs) {
+    return [];
+  }
+
+  const groupTotals = new Map<string, number>();
+  allWindowActivities.value.forEach((activitySession) => {
+    const activityGroup = getActivityGroupFromActivityName(activitySession.type);
+    groupTotals.set(
+      activityGroup,
+      (groupTotals.get(activityGroup) ?? 0) + activitySession.totalDurationMs
+    );
+  });
+
+  const sortedActivities = Array.from(groupTotals.entries())
+    .map(([activityGroup, value]) => {
+      const colorKey = getTailwindClassFromActivity(activityGroup, true) as keyof typeof Color;
+      return {
+        name: ACTIVITY_LABELS[activityGroup] || 'Other',
+        value,
+        color: Color[colorKey],
+        type: activityGroup,
+        percentage: value / totalDurationMs
+      };
+    })
+    .filter((activity) => activity.value > 0)
+    .sort((a, b) => b.value - a.value);
+
+  let includedDurationMs = 0;
+  const visibleActivities: ActivityBreakdownDataPoint[] = [];
+
+  for (const activity of sortedActivities) {
+    if (includedDurationMs / totalDurationMs >= ACTIVITY_BREAKDOWN_COVERAGE) {
+      break;
     }
-    if (activity.end.getTime() > acc) {
-      return activity.end.getTime()
-    }
-    return acc
-  }, 0) ?? 0
-})
+    visibleActivities.push(activity);
+    includedDurationMs += activity.value;
+  }
+
+  return visibleActivities;
+});
+
+const activityBreakdownStyle = computed((): CSSProperties => {
+  if (!activityBreakdownData.value.length) {
+    return {};
+  }
+
+  let offset = 0;
+  const segments = activityBreakdownData.value.map((activity) => {
+    const start = offset;
+    offset += activity.percentage * 360;
+    return `${activity.color} ${start}deg ${offset}deg`;
+  });
+
+  if (offset < 360) {
+    segments.push(`${Color['neutral-200']} ${offset}deg 360deg`);
+  }
+
+  return {
+    background: `conic-gradient(${segments.join(', ')})`
+  };
+});
 
 onMounted(async () => {
-  await loadData()
-})
+  await loadData();
+});
 
 async function loadData() {
-  isLoading.value = true
-  await loadLongestTimeActive()
-  await loadMostActiveApps()
-  await loadWindowActivities()
-  isLoading.value = false
+  isLoading.value = true;
+  await loadLongestTimeActive();
+  await loadMostActiveApps();
+  await loadWindowActivities();
+  isLoading.value = false;
 }
 
 function windowActivitiesToChartData() {
-  let dataPoints: ChartDataPoint[] = []
+  const dataPoints: ChartDataPoint[] = [];
 
   allWindowActivities.value?.forEach((activitySession: ActivitySessions) => {
     activitySession.sessions.forEach((session: TimeActive) => {
@@ -58,103 +150,129 @@ function windowActivitiesToChartData() {
         start: session.from,
         end: session.to,
         color: getTailwindClassFromActivity(activitySession.type)
-      })
-    })
-  })
+      });
+    });
+  });
 
-  chartDataWindowActivities.value = dataPoints
+  chartDataWindowActivities.value = dataPoints;
 }
 
 async function loadWindowActivities() {
-  allWindowActivities.value = await typedIpcRenderer.invoke('retrospectionGetActivities', selectedDay.value) as ActivitySessions[]
-  windowActivitiesToChartData()
-  topActivities.value = allWindowActivities.value?.sort((a: ActivitySessions, b: ActivitySessions) => b.totalDurationMs - a.totalDurationMs).slice(0, 3) ?? []
+  allWindowActivities.value = (await typedIpcRenderer.invoke(
+    'retrospectionGetActivities',
+    selectedDay.value
+  )) as ActivitySessions[];
+  windowActivitiesToChartData();
+  topActivities.value =
+    [...allWindowActivities.value]
+      ?.sort((a: ActivitySessions, b: ActivitySessions) => b.totalDurationMs - a.totalDurationMs)
+      .slice(0, 3) ?? [];
 }
 
 async function loadLongestTimeActive() {
   try {
-    longestTimeActive.value = await typedIpcRenderer.invoke('retrospectionLoadLongestTimeActive', selectedDay.value) as TimeActive
+    longestTimeActive.value = (await typedIpcRenderer.invoke(
+      'retrospectionLoadLongestTimeActive',
+      selectedDay.value
+    )) as TimeActive;
   } catch (error) {
-    console.error('Error loading longest time active', error)
+    console.error('Error loading longest time active', error);
   }
 }
 
 async function loadMostActiveApps() {
   try {
-    topApps.value = await typedIpcRenderer.invoke('retrospectionGetTopThreeMostActiveApps', selectedDay.value) as ActivitySessions[]
+    topApps.value = (await typedIpcRenderer.invoke(
+      'retrospectionGetTopThreeMostActiveApps',
+      selectedDay.value
+    )) as ActivitySessions[];
   } catch (error) {
-    console.error('Error loading most active apps', error)
+    console.error('Error loading most active apps', error);
   }
 }
 
 function msToMinutes(ms: number): number {
-  return Math.round(ms / 60000)
+  return Math.round(ms / 60000);
 }
 
 function renderTime(ms: number): string {
-  let minutes = msToMinutes(ms)
+  let minutes = msToMinutes(ms);
   if (minutes < 60) {
-    return `${minutes} minutes`
+    return `${minutes} minutes`;
   }
 
-  let hours = Math.floor(minutes / 60)
-  minutes = minutes % 60
+  const hours = Math.floor(minutes / 60);
+  minutes = minutes % 60;
   if (minutes === 0) {
     if (hours === 1) {
-      return `${hours} hour`
+      return `${hours} hour`;
     } else {
-      return `${hours} hours`
+      return `${hours} hours`;
     }
   } else {
-    let fractionalHours = Math.round(minutes / 60 * 10) / 10
-    return `${hours + fractionalHours} hours`
+    const fractionalHours = Math.round((minutes / 60) * 10) / 10;
+    return `${hours + fractionalHours} hours`;
   }
+}
+
+function renderCompactTime(ms: number): string {
+  const minutes = msToMinutes(ms);
+  if (minutes < 1) {
+    return '< 1 min';
+  }
+  if (minutes < 60) {
+    return `${minutes} min`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes ? `${hours} hr ${remainingMinutes} min` : `${hours} hr`;
 }
 
 async function handleDayChange(event: Event) {
-  const value = (event.target as HTMLInputElement).value
-  if (!value) return
-  selectedDay.value = new Date(value)
-  await loadData()
+  const value = (event.target as HTMLInputElement).value;
+  if (!value) return;
+  selectedDay.value = new Date(value);
+  await loadData();
 }
 
 function getNearestFullHourTime(time: number, offset: number): number {
-  const nextFullHour = new Date(time)
-  nextFullHour.setHours(nextFullHour.getHours() + offset, 0, 0, 0)
-  return nextFullHour.getTime()
+  const nextFullHour = new Date(time);
+  nextFullHour.setHours(nextFullHour.getHours() + offset, 0, 0, 0);
+  return nextFullHour.getTime();
 }
 
 function getTimeString(date: Date | string | number): string {
-  const d = new Date(date)
-  const hours = d.getHours().toString().padStart(2, '0')
-  const minutes = d.getMinutes().toString().padStart(2, '0')
-  return `${hours}:${minutes}`
+  const d = new Date(date);
+  const hours = d.getHours().toString().padStart(2, '0');
+  const minutes = d.getMinutes().toString().padStart(2, '0');
+  return `${hours}:${minutes}`;
 }
 
 function getDayLabel(date: Date): string {
-  const today = new Date()
-  const yesterday = new Date()
-  yesterday.setDate(yesterday.getDate() - 1)
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
 
   if (
     date.getDate() === today.getDate() &&
     date.getMonth() === today.getMonth() &&
     date.getFullYear() === today.getFullYear()
   ) {
-    return 'Today'
+    return 'Today';
   } else if (
     date.getDate() === yesterday.getDate() &&
     date.getMonth() === yesterday.getMonth() &&
     date.getFullYear() === yesterday.getFullYear()
   ) {
-    return 'Yesterday'
+    return 'Yesterday';
   } else {
     return date.toLocaleDateString(undefined, {
       weekday: 'short',
       month: 'short',
       day: 'numeric',
       year: 'numeric'
-    })
+    });
   }
 }
 </script>
@@ -162,65 +280,101 @@ function getDayLabel(date: Date): string {
 <template>
   <!-- No data for this day -->
   <template v-if="!allWindowActivities || allWindowActivities.length === 0">
-    <div class="flex justify-center items-center h-screen">
+    <div class="flex h-screen items-center justify-center">
       <!-- day picker -->
-      <div class="absolute top-6 right-6 z-10">
-        <input type="date" :value="selectedDay.toISOString().substring(0, 10)" @change="handleDayChange"
+      <div class="absolute right-6 top-6 z-10">
+        <input
+          type="date"
+          :value="selectedDay.toISOString().substring(0, 10)"
           :max="new Date().toISOString().substring(0, 10)"
-          class="rounded px-2 py-1 bg-white text-gray-800 border border-gray-300 dark:bg-neutral-700 dark:text-slate-200 dark:border-neutral-600" style="min-width: 140px;" />
+          class="rounded border border-gray-300 bg-white px-2 py-1 text-gray-800 dark:border-neutral-600 dark:bg-neutral-700 dark:text-slate-200"
+          style="min-width: 140px"
+          @change="handleDayChange"
+        />
       </div>
       <div class="text-center text-gray-800 dark:text-gray-200">
         <h1 class="mb-8 text-2xl font-bold">No data for this day.</h1>
-        <span class="text-gray-600 dark:text-gray-400">There is no data recorded for this date. Please select a different day.</span>
+        <span class="text-gray-600 dark:text-gray-400"
+          >There is no data recorded for this date. Please select a different day.</span
+        >
       </div>
     </div>
   </template>
 
   <!-- Retrospection dashboard -->
   <template v-else>
-    <div class="view h-screen flex flex-col overflow-y-auto">
+    <div class="view flex h-screen flex-col overflow-y-auto">
       <!-- day picker -->
-      <div class="absolute top-6 right-6 z-10">
-        <input type="date" :value="selectedDay.toISOString().substring(0, 10)" @change="handleDayChange"
+      <div class="absolute right-6 top-6 z-10">
+        <input
+          type="date"
+          :value="selectedDay.toISOString().substring(0, 10)"
           :max="new Date().toISOString().substring(0, 10)"
-          class="rounded px-2 py-1 bg-white text-gray-800 border border-gray-300 dark:bg-neutral-700 dark:text-slate-200 dark:border-neutral-600" style="min-width: 140px;" />
+          class="rounded border border-gray-300 bg-white px-2 py-1 text-gray-800 dark:border-neutral-600 dark:bg-neutral-700 dark:text-slate-200"
+          style="min-width: 140px"
+          @change="handleDayChange"
+        />
       </div>
 
       <div>
-        <h1 class="mb-3 text-2xl font-bold primary-blue">{{ getDayLabel(selectedDay) }} - in Review</h1>
-        <div class="subline mb-8 text-gray-600 dark:text-gray-400">Take a moment to reflect on your workday.</div>
+        <h1 class="primary-blue mb-3 text-2xl font-bold">
+          {{ getDayLabel(selectedDay) }} - in Review
+        </h1>
+        <div class="subline mb-8 text-gray-600 dark:text-gray-400">
+          Take a moment to reflect on your workday.
+        </div>
 
         <!-- Timeline Visualization -->
-        <h1 class="mt-8 font-bold mb-2 text-xl text-gray-900 dark:text-gray-100">Activities over time</h1>
-        <StackedBarChart v-if="!isLoading && chartDataWindowActivities" :data="chartDataWindowActivities"
+        <h1 class="mb-2 mt-8 text-xl font-bold text-gray-900 dark:text-gray-100">
+          Activities over time
+        </h1>
+        <StackedBarChart
+          v-if="!isLoading && chartDataWindowActivities"
+          :data="chartDataWindowActivities"
           :start-date="getNearestFullHourTime(earliestUserComputerActivity, 0)"
-          :end-date="getNearestFullHourTime(latestUserComputerActivity, 1)" type="WINDOW_ACTIVITY" />
+          :end-date="getNearestFullHourTime(latestUserComputerActivity, 1)"
+          type="WINDOW_ACTIVITY"
+        />
 
         <!-- Info Tiles -->
-        <h1 class="mt-8 font-bold mb-2 text-xl text-gray-900 dark:text-gray-100">Insights of your day</h1>
+        <h1 class="mb-2 mt-8 text-xl font-bold text-gray-900 dark:text-gray-100">
+          Insights of your day
+        </h1>
         <div class="tile-grid">
-
           <!-- Tile 1: Longest active period -->
-          <div v-if="longestTimeActive" class="text-gray-800 bg-gray-100 border border-gray-200 rounded px-4 py-3 dark:text-slate-200 dark:bg-neutral-800 dark:border-transparent">
-            <h2 class="leading-4 primary-blue font-bold">Longest active period</h2>
+          <div
+            v-if="longestTimeActive"
+            class="rounded border border-gray-200 bg-gray-100 px-4 py-3 text-gray-800 dark:border-transparent dark:bg-neutral-800 dark:text-slate-200"
+          >
+            <h2 class="primary-blue font-bold leading-4">Longest active period</h2>
             <p class="mt-2">
-              Your longest active streak was <b>{{ renderTime(longestTimeActive!.duration * 60000) }}</b> (between {{
-                getTimeString(longestTimeActive!.from) }} and {{ getTimeString(longestTimeActive!.to) }}).
+              Your longest active streak was
+              <b>{{ renderTime(longestTimeActive!.duration * 60000) }}</b> (between
+              {{ getTimeString(longestTimeActive!.from) }} and
+              {{ getTimeString(longestTimeActive!.to) }}).
             </p>
           </div>
 
           <!-- Tile 2: Active hours -->
-          <div v-if="topActivities" class="text-gray-800 bg-gray-100 border border-gray-200 rounded px-4 py-3 dark:text-slate-200 dark:bg-neutral-800 dark:border-transparent">
-            <h2 class="leading-4 primary-blue font-bold">Active hours on computer</h2>
+          <div
+            v-if="topActivities"
+            class="rounded border border-gray-200 bg-gray-100 px-4 py-3 text-gray-800 dark:border-transparent dark:bg-neutral-800 dark:text-slate-200"
+          >
+            <h2 class="primary-blue font-bold leading-4">Active hours on computer</h2>
             <p class="mt-2">
-              You were active for <b>{{ renderTime(latestUserComputerActivity - earliestUserComputerActivity) }}</b> (between {{
-                getTimeString(earliestUserComputerActivity) }} and {{ getTimeString(latestUserComputerActivity) }}).
+              You were active for
+              <b>{{ renderTime(latestUserComputerActivity - earliestUserComputerActivity) }}</b>
+              (between {{ getTimeString(earliestUserComputerActivity) }} and
+              {{ getTimeString(latestUserComputerActivity) }}).
             </p>
           </div>
 
           <!-- Tile 3: Top apps -->
-          <div v-if="topApps" class="text-gray-800 bg-gray-100 border border-gray-200 rounded px-4 py-3 dark:text-slate-200 dark:bg-neutral-800 dark:border-transparent">
-            <h2 class="leading-4 primary-blue font-bold">Top apps</h2>
+          <div
+            v-if="topApps"
+            class="rounded border border-gray-200 bg-gray-100 px-4 py-3 text-gray-800 dark:border-transparent dark:bg-neutral-800 dark:text-slate-200"
+          >
+            <h2 class="primary-blue font-bold leading-4">Top apps</h2>
             <ol class="mt-2 list-decimal pl-4">
               <li v-for="(appSession, index) in topApps" :key="index">
                 {{ appSession.type }}: {{ renderTime(appSession.totalDurationMs) }}
@@ -228,16 +382,50 @@ function getDayLabel(date: Date): string {
             </ol>
           </div>
 
-          <!-- Tile 4: Top activities -->
-          <div v-if="topActivities" class="text-gray-800 bg-gray-100 border border-gray-200 rounded px-4 py-3 dark:text-slate-200 dark:bg-neutral-800 dark:border-transparent">
-            <h2 class="leading-4 primary-blue font-bold">Top activities pursued</h2>
+          <!-- Tile 4: Activity breakdown -->
+          <div
+            v-if="activityBreakdownData.length"
+            class="activity-breakdown-card rounded border border-gray-200 bg-gray-100 px-4 py-3 text-gray-800 dark:border-transparent dark:bg-neutral-800 dark:text-slate-200"
+          >
+            <h2 class="primary-blue font-bold leading-4">Activity Breakdown</h2>
+            <div class="activity-breakdown-content">
+              <div class="activity-pie" :style="activityBreakdownStyle" aria-hidden="true">
+                <div class="activity-pie-hole"></div>
+              </div>
+              <ol class="activity-breakdown-list">
+                <li
+                  v-for="activity in activityBreakdownData"
+                  :key="activity.type"
+                  :title="`${activity.name}: ${renderCompactTime(activity.value)}`"
+                >
+                  <span class="activity-breakdown-label">
+                    <span
+                      class="activity-breakdown-dot"
+                      :style="{ backgroundColor: activity.color }"
+                    ></span>
+                    <span class="activity-breakdown-name">{{ activity.name }}</span>
+                  </span>
+                  <span class="activity-breakdown-time">{{
+                    renderCompactTime(activity.value)
+                  }}</span>
+                </li>
+              </ol>
+            </div>
+          </div>
+
+          <!-- Tile 5: Top activities -->
+          <div
+            v-if="topActivities"
+            class="rounded border border-gray-200 bg-gray-100 px-4 py-3 text-gray-800 dark:border-transparent dark:bg-neutral-800 dark:text-slate-200"
+          >
+            <h2 class="primary-blue font-bold leading-4">Top activities pursued</h2>
             <ol class="mt-2 list-decimal pl-4">
               <li v-for="(activitySession, index) in topActivities" :key="index">
-                {{ ACTIVITY_LABELS[activitySession.type] || 'Other' }}: {{ renderTime(activitySession.totalDurationMs) }}
+                {{ ACTIVITY_LABELS[activitySession.type] || 'Other' }}:
+                {{ renderTime(activitySession.totalDurationMs) }}
               </li>
             </ol>
           </div>
-
         </div>
       </div>
     </div>
@@ -264,5 +452,107 @@ h2.primary-blue {
   grid-template-columns: repeat(2, 1fr);
   gap: 1.2rem;
   width: 100%;
+}
+
+.activity-breakdown-card {
+  min-height: 128px;
+}
+
+.activity-breakdown-content {
+  display: grid;
+  grid-template-columns: 86px minmax(0, 1fr);
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+
+.activity-pie {
+  position: relative;
+  width: 86px;
+  height: 86px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+
+.activity-pie-hole {
+  position: absolute;
+  inset: 20px;
+  border-radius: 50%;
+  background: #f3f4f6;
+}
+
+:global(.dark) .activity-pie-hole {
+  background: #262626;
+}
+
+.activity-breakdown-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.activity-breakdown-list li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+  font-size: 0.9rem;
+  line-height: 1.1rem;
+}
+
+.activity-breakdown-label {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 0.45rem;
+}
+
+.activity-breakdown-dot {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+
+.activity-breakdown-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-breakdown-time {
+  color: #374151;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+:global(.dark) .activity-breakdown-time {
+  color: #e5e7eb;
+}
+
+@media (max-width: 720px) {
+  .tile-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 420px) {
+  .activity-breakdown-content {
+    grid-template-columns: 72px minmax(0, 1fr);
+  }
+
+  .activity-pie {
+    width: 72px;
+    height: 72px;
+  }
+
+  .activity-pie-hole {
+    inset: 17px;
+  }
 }
 </style>

--- a/src/electron/src/views/RetrospectionView.vue
+++ b/src/electron/src/views/RetrospectionView.vue
@@ -25,6 +25,7 @@ const longestTimeActive = ref<TimeActive | undefined>(undefined);
 const topApps = ref<ActivitySessions[] | undefined>(undefined);
 const ACTIVITY_BREAKDOWN_COVERAGE = 0.9;
 const ACTIVITY_BREAKDOWN_MAX_ITEMS = 6;
+const EXCLUDED_ACTIVITY_BREAKDOWN_GROUPS = new Set(['Other', 'Unknown']);
 
 interface ActivityBreakdownDataPoint extends PieChartDataPoint {
   percentage: number;
@@ -74,6 +75,12 @@ const activityBreakdownData = computed((): ActivityBreakdownDataPoint[] => {
   const groupTotals = new Map<string, number>();
   allWindowActivities.value.forEach((activitySession) => {
     const activityGroup = getActivityGroupFromActivityName(activitySession.type);
+    if (
+      EXCLUDED_ACTIVITY_BREAKDOWN_GROUPS.has(activityGroup) ||
+      EXCLUDED_ACTIVITY_BREAKDOWN_GROUPS.has(activitySession.type)
+    ) {
+      return;
+    }
     groupTotals.set(
       activityGroup,
       (groupTotals.get(activityGroup) ?? 0) + activitySession.totalDurationMs
@@ -81,11 +88,10 @@ const activityBreakdownData = computed((): ActivityBreakdownDataPoint[] => {
   });
 
   const sortedActivities = Array.from(groupTotals.entries())
-    .filter(([activityGroup]) => activityGroup !== 'Other')
     .map(([activityGroup, value]) => {
       const colorKey = getTailwindClassFromActivity(activityGroup, true) as keyof typeof Color;
       return {
-        name: ACTIVITY_LABELS[activityGroup] || 'Other',
+        name: ACTIVITY_LABELS[activityGroup],
         value,
         color: Color[colorKey],
         type: activityGroup,
@@ -490,7 +496,7 @@ h2.primary-blue {
 .activity-breakdown-list {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.15rem;
   min-width: 0;
   margin: 0;
   padding: 0;
@@ -503,7 +509,7 @@ h2.primary-blue {
   align-items: center;
   gap: 0.75rem;
   min-width: 0;
-  line-height: 1.5rem;
+  line-height: 1.3rem;
 }
 
 .activity-breakdown-label {
@@ -527,7 +533,6 @@ h2.primary-blue {
 }
 
 .activity-breakdown-time {
-  font-weight: 700;
   white-space: nowrap;
 }
 

--- a/src/electron/src/views/RetrospectionView.vue
+++ b/src/electron/src/views/RetrospectionView.vue
@@ -23,8 +23,8 @@ const allWindowActivities = ref<ActivitySessions[]>([]);
 const chartDataWindowActivities = ref<ChartDataPoint[]>();
 const longestTimeActive = ref<TimeActive | undefined>(undefined);
 const topApps = ref<ActivitySessions[] | undefined>(undefined);
-const topActivities = ref<ActivitySessions[]>([]);
 const ACTIVITY_BREAKDOWN_COVERAGE = 0.9;
+const ACTIVITY_BREAKDOWN_MAX_ITEMS = 6;
 
 interface ActivityBreakdownDataPoint extends PieChartDataPoint {
   percentage: number;
@@ -55,6 +55,7 @@ const latestUserComputerActivity = computed((): number => {
   );
 });
 
+// Total tracked activity time is the denominator for percentages and the 90% cutoff.
 const activityBreakdownTotalMs = computed((): number => {
   return (
     allWindowActivities.value?.reduce((total, activitySession) => {
@@ -63,6 +64,7 @@ const activityBreakdownTotalMs = computed((): number => {
   );
 });
 
+// Groups raw activities into the same activity categories and colors used by the timeline.
 const activityBreakdownData = computed((): ActivityBreakdownDataPoint[] => {
   const totalDurationMs = activityBreakdownTotalMs.value;
   if (!totalDurationMs) {
@@ -79,6 +81,7 @@ const activityBreakdownData = computed((): ActivityBreakdownDataPoint[] => {
   });
 
   const sortedActivities = Array.from(groupTotals.entries())
+    .filter(([activityGroup]) => activityGroup !== 'Other')
     .map(([activityGroup, value]) => {
       const colorKey = getTailwindClassFromActivity(activityGroup, true) as keyof typeof Color;
       return {
@@ -96,7 +99,10 @@ const activityBreakdownData = computed((): ActivityBreakdownDataPoint[] => {
   const visibleActivities: ActivityBreakdownDataPoint[] = [];
 
   for (const activity of sortedActivities) {
-    if (includedDurationMs / totalDurationMs >= ACTIVITY_BREAKDOWN_COVERAGE) {
+    if (
+      visibleActivities.length >= ACTIVITY_BREAKDOWN_MAX_ITEMS ||
+      includedDurationMs / totalDurationMs >= ACTIVITY_BREAKDOWN_COVERAGE
+    ) {
       break;
     }
     visibleActivities.push(activity);
@@ -106,6 +112,14 @@ const activityBreakdownData = computed((): ActivityBreakdownDataPoint[] => {
   return visibleActivities;
 });
 
+const activityBreakdownTitle = computed((): string => {
+  const shownActivities = activityBreakdownData.value.length;
+  return shownActivities
+    ? `Activity Breakdown (top ${shownActivities} activities)`
+    : 'Activity Breakdown';
+});
+
+// Builds the donut from visible activities and leaves any dropped tail as a neutral segment.
 const activityBreakdownStyle = computed((): CSSProperties => {
   if (!activityBreakdownData.value.length) {
     return {};
@@ -163,10 +177,6 @@ async function loadWindowActivities() {
     selectedDay.value
   )) as ActivitySessions[];
   windowActivitiesToChartData();
-  topActivities.value =
-    [...allWindowActivities.value]
-      ?.sort((a: ActivitySessions, b: ActivitySessions) => b.totalDurationMs - a.totalDurationMs)
-      .slice(0, 3) ?? [];
 }
 
 async function loadLongestTimeActive() {
@@ -357,7 +367,7 @@ function getDayLabel(date: Date): string {
 
           <!-- Tile 2: Active hours -->
           <div
-            v-if="topActivities"
+            v-if="chartDataWindowActivities?.length"
             class="rounded border border-gray-200 bg-gray-100 px-4 py-3 text-gray-800 dark:border-transparent dark:bg-neutral-800 dark:text-slate-200"
           >
             <h2 class="primary-blue font-bold leading-4">Active hours on computer</h2>
@@ -387,7 +397,7 @@ function getDayLabel(date: Date): string {
             v-if="activityBreakdownData.length"
             class="activity-breakdown-card rounded border border-gray-200 bg-gray-100 px-4 py-3 text-gray-800 dark:border-transparent dark:bg-neutral-800 dark:text-slate-200"
           >
-            <h2 class="primary-blue font-bold leading-4">Activity Breakdown</h2>
+            <h2 class="primary-blue font-bold leading-4">{{ activityBreakdownTitle }}</h2>
             <div class="activity-breakdown-content">
               <div class="activity-pie" :style="activityBreakdownStyle" aria-hidden="true">
                 <div class="activity-pie-hole"></div>
@@ -405,26 +415,12 @@ function getDayLabel(date: Date): string {
                     ></span>
                     <span class="activity-breakdown-name">{{ activity.name }}</span>
                   </span>
-                  <span class="activity-breakdown-time">{{
+                  <span class="activity-breakdown-time text-slate-700 dark:!text-slate-100">{{
                     renderCompactTime(activity.value)
                   }}</span>
                 </li>
               </ol>
             </div>
-          </div>
-
-          <!-- Tile 5: Top activities -->
-          <div
-            v-if="topActivities"
-            class="rounded border border-gray-200 bg-gray-100 px-4 py-3 text-gray-800 dark:border-transparent dark:bg-neutral-800 dark:text-slate-200"
-          >
-            <h2 class="primary-blue font-bold leading-4">Top activities pursued</h2>
-            <ol class="mt-2 list-decimal pl-4">
-              <li v-for="(activitySession, index) in topActivities" :key="index">
-                {{ ACTIVITY_LABELS[activitySession.type] || 'Other' }}:
-                {{ renderTime(activitySession.totalDurationMs) }}
-              </li>
-            </ol>
           </div>
         </div>
       </div>
@@ -485,6 +481,10 @@ h2.primary-blue {
   .activity-pie-hole {
     background: #262626;
   }
+
+  .activity-breakdown-time {
+    color: #f1f5f9;
+  }
 }
 
 .activity-breakdown-list {
@@ -503,8 +503,7 @@ h2.primary-blue {
   align-items: center;
   gap: 0.75rem;
   min-width: 0;
-  font-size: 0.9rem;
-  line-height: 1.1rem;
+  line-height: 1.5rem;
 }
 
 .activity-breakdown-label {
@@ -528,13 +527,13 @@ h2.primary-blue {
 }
 
 .activity-breakdown-time {
-  color: #374151;
-  font-weight: 600;
+  font-weight: 700;
   white-space: nowrap;
 }
 
-:global(.dark) .activity-breakdown-time {
-  color: #e5e7eb;
+:global(.dark) .activity-breakdown-time,
+:global([data-theme='dark']) .activity-breakdown-time {
+  color: #f1f5f9;
 }
 
 @media (max-width: 720px) {

--- a/src/electron/src/views/RetrospectionView.vue
+++ b/src/electron/src/views/RetrospectionView.vue
@@ -481,8 +481,10 @@ h2.primary-blue {
   background: #f3f4f6;
 }
 
-:global(.dark) .activity-pie-hole {
-  background: #262626;
+@media (prefers-color-scheme: dark) {
+  .activity-pie-hole {
+    background: #262626;
+  }
 }
 
 .activity-breakdown-list {


### PR DESCRIPTION
# Add Activity Breakdown to Retrospection (Closes #514)

## Description

Adds a compact `Activity Breakdown` card to Retrospection. The card shows the top activity categories for the selected day as a donut chart with durations.

### Changes Made

- Added `Activity Breakdown` card
- Groups activities using the existing Retrospection activity labels and colors
- Shows the largest activity categories covering roughly 90% of tracked time
- 
## Screenshots

| Light mode | Dark mode |
|:-:|:-:|
| <img width="400" alt="Activity breakdown in light mode" src="https://github.com/user-attachments/assets/5f7a5cab-b06f-418b-a4fa-29d52ef124c3" /> | <img width="400" alt="Activity breakdown in dark mode" src="https://github.com/user-attachments/assets/6f49377b-5760-4240-ba5f-50c3de8683a9" /> |

Closes #514