### PR TITLE
[#525] Preserve overdue daily survey date

### DIFF
--- a/src/electron/electron/ipc/IpcHandler.ts
+++ b/src/electron/electron/ipc/IpcHandler.ts
@@ -349,9 +349,13 @@ export class IpcHandler {
   private async createDailySurveyResponses(
     promptedAt: Date,
     samplingType: DailySurveySamplingType,
+    scheduledDate: Date | null,
     responses: DailySurveyResponseInput[]
   ): Promise<void> {
     await this.dailySurveyService.createDailySurveyResponses(promptedAt, samplingType, responses);
+    if (this.dailySurveyTracker) {
+      await this.dailySurveyTracker.complete(samplingType, scheduledDate ? new Date(scheduledDate) : null);
+    }
   }
 
   private resizeDailySurveyWindow(height: number): void {
@@ -363,13 +367,16 @@ export class IpcHandler {
   }
 
   private async postponeDailySurvey(samplingType: DailySurveySamplingType, minutes: number): Promise<void> {
+    if (this.dailySurveyTracker) {
+      const wasPostponed = await this.dailySurveyTracker.postpone(samplingType, minutes);
+      if (!wasPostponed) {
+        return;
+      }
+    }
     UsageDataService.createNewUsageDataEvent(
       UsageDataEventType.DailySurveyPostponed,
       JSON.stringify({ samplingType, postponedMinutes: minutes })
     );
-    if (this.dailySurveyTracker) {
-      await this.dailySurveyTracker.postpone(samplingType, minutes);
-    }
     this.windowService.closeDailySurveyWindow(false, false);
   }
 

--- a/src/electron/electron/main/entities/Settings.ts
+++ b/src/electron/electron/main/entities/Settings.ts
@@ -63,4 +63,10 @@ export class Settings extends BaseEntity {
 
   @Column('datetime', { nullable: true })
   nextDailySurveyEveningInvocation: Date;
+
+  @Column('datetime', { nullable: true })
+  postponedDailySurveyMorningUntil: Date | null;
+
+  @Column('datetime', { nullable: true })
+  postponedDailySurveyEveningUntil: Date | null;
 }

--- a/src/electron/electron/main/services/trackers/DailySurveyTracker.ts
+++ b/src/electron/electron/main/services/trackers/DailySurveyTracker.ts
@@ -12,6 +12,7 @@ const weekDays = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'satur
 
 export class DailySurveyTracker implements Tracker {
   private checkJob: schedule.Job;
+  private openSurveyKeys = new Set<DailySurveySamplingType>();
   private readonly windowService: WindowService;
   private readonly workScheduleService: WorkScheduleService;
   private readonly surveys: DailySurveyConfig[];
@@ -59,11 +60,14 @@ export class DailySurveyTracker implements Tracker {
 
       for (const survey of this.surveys) {
         const invocationField = this.getInvocationField(survey.samplingType);
+        const postponedUntilField = this.getPostponedUntilField(survey.samplingType);
         const nextInvocation = settings[invocationField];
-        if (nextInvocation && nextInvocation <= now) {
+        const postponedUntil = settings[postponedUntilField];
+        const isPostponed = postponedUntil && postponedUntil > now;
+        if (nextInvocation && nextInvocation <= now && !isPostponed && !this.openSurveyKeys.has(survey.samplingType)) {
           LOG.info(`Daily survey (${survey.samplingType}) is due`);
+          this.openSurveyKeys.add(survey.samplingType);
           await this.windowService.createDailySurveyWindow(survey.samplingType, nextInvocation);
-          await this.scheduleNextForSurvey(survey);
         }
       }
     });
@@ -72,11 +76,21 @@ export class DailySurveyTracker implements Tracker {
   private async scheduleAllSurveys(): Promise<void> {
     for (const survey of this.surveys) {
       const invocationField = this.getInvocationField(survey.samplingType);
+      const postponedUntilField = this.getPostponedUntilField(survey.samplingType);
       const settings: Settings = await Settings.findOneBy({ onlyOneEntityShouldExist: 1 });
-      if (settings[invocationField] && settings[invocationField] <= new Date()) {
+      const now = new Date();
+      const postponedUntil = settings[postponedUntilField];
+      const isPostponed = postponedUntil && postponedUntil > now;
+      if (
+        settings[invocationField] &&
+        settings[invocationField] <= now &&
+        !isPostponed &&
+        !this.openSurveyKeys.has(survey.samplingType)
+      ) {
         LOG.info(`Daily survey (${survey.samplingType}) was due at ${settings[invocationField]}, showing now`);
+        this.openSurveyKeys.add(survey.samplingType);
+        // Keep nextInvocation unchanged until submit/skip so unattended app starts do not lose the original survey date.
         await this.windowService.createDailySurveyWindow(survey.samplingType, settings[invocationField]);
-        await this.scheduleNextForSurvey(survey);
       } else if (!settings[invocationField]) {
         await this.scheduleNextForSurvey(survey);
       }
@@ -88,6 +102,7 @@ export class DailySurveyTracker implements Tracker {
     const settings: Settings = await Settings.findOneBy({ onlyOneEntityShouldExist: 1 });
 
     settings[this.getInvocationField(survey.samplingType)] = nextInvocation;
+    settings[this.getPostponedUntilField(survey.samplingType)] = null;
 
     await settings.save();
     LOG.info(`Next ${survey.samplingType} daily survey scheduled for ${nextInvocation}`);
@@ -134,13 +149,51 @@ export class DailySurveyTracker implements Tracker {
     throw new Error(`Unknown samplingType: ${samplingType}`);
   }
 
-  public async postpone(samplingType: DailySurveySamplingType, minutes: number): Promise<void> {
+  private getPostponedUntilField(samplingType: DailySurveySamplingType): 'postponedDailySurveyMorningUntil' | 'postponedDailySurveyEveningUntil' {
+    if (samplingType === 'morning') return 'postponedDailySurveyMorningUntil';
+    if (samplingType === 'evening') return 'postponedDailySurveyEveningUntil';
+    throw new Error(`Unknown samplingType: ${samplingType}`);
+  }
+
+  private isBeforeToday(date: Date): boolean {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const compare = new Date(date);
+    compare.setHours(0, 0, 0, 0);
+    return compare < today;
+  }
+
+  public async complete(samplingType: DailySurveySamplingType, scheduledDate?: Date | null): Promise<void> {
+    this.openSurveyKeys.delete(samplingType);
+
+    if (!scheduledDate) {
+      return;
+    }
+
+    const survey = this.surveys.find((s) => s.samplingType === samplingType);
+    if (!survey) {
+      throw new Error(`Unknown daily survey samplingType: ${samplingType}`);
+    }
+
+    await this.scheduleNextForSurvey(survey);
+  }
+
+  public async postpone(samplingType: DailySurveySamplingType, minutes: number): Promise<boolean> {
     const settings: Settings = await Settings.findOneBy({ onlyOneEntityShouldExist: 1 });
+    const scheduledDate = settings[this.getInvocationField(samplingType)];
+    if (scheduledDate && this.isBeforeToday(scheduledDate)) {
+      LOG.info(`Daily survey (${samplingType}) was scheduled on a previous day and cannot be postponed`);
+      return false;
+    }
+
     const newTime = new Date(Date.now() + minutes * 60 * 1000);
 
-    settings[this.getInvocationField(samplingType)] = newTime;
+    // Store postponement separately so the original scheduled day remains available for late-survey messaging.
+    settings[this.getPostponedUntilField(samplingType)] = newTime;
+    this.openSurveyKeys.delete(samplingType);
 
     await settings.save();
     LOG.info(`Daily survey (${samplingType}) postponed by ${minutes} minutes to ${newTime}`);
+    return true;
   }
 }

--- a/src/electron/electron/main/services/trackers/DailySurveyTracker.ts
+++ b/src/electron/electron/main/services/trackers/DailySurveyTracker.ts
@@ -4,7 +4,10 @@ import { Tracker } from './Tracker';
 import getMainLogger from '../../../config/Logger';
 import { Settings } from '../../entities/Settings';
 import { WorkScheduleService } from '../WorkScheduleService';
-import type { DailySurveyConfig, DailySurveySamplingType } from '../../../../shared/StudyConfiguration';
+import type {
+  DailySurveyConfig,
+  DailySurveySamplingType
+} from '../../../../shared/StudyConfiguration';
 
 const LOG = getMainLogger('DailySurveyTracker');
 
@@ -64,7 +67,12 @@ export class DailySurveyTracker implements Tracker {
         const nextInvocation = settings[invocationField];
         const postponedUntil = settings[postponedUntilField];
         const isPostponed = postponedUntil && postponedUntil > now;
-        if (nextInvocation && nextInvocation <= now && !isPostponed && !this.openSurveyKeys.has(survey.samplingType)) {
+        if (
+          nextInvocation &&
+          nextInvocation <= now &&
+          !isPostponed &&
+          !this.openSurveyKeys.has(survey.samplingType)
+        ) {
           LOG.info(`Daily survey (${survey.samplingType}) is due`);
           this.openSurveyKeys.add(survey.samplingType);
           await this.windowService.createDailySurveyWindow(survey.samplingType, nextInvocation);
@@ -87,10 +95,15 @@ export class DailySurveyTracker implements Tracker {
         !isPostponed &&
         !this.openSurveyKeys.has(survey.samplingType)
       ) {
-        LOG.info(`Daily survey (${survey.samplingType}) was due at ${settings[invocationField]}, showing now`);
+        LOG.info(
+          `Daily survey (${survey.samplingType}) was due at ${settings[invocationField]}, showing now`
+        );
         this.openSurveyKeys.add(survey.samplingType);
         // Keep nextInvocation unchanged until submit/skip so unattended app starts do not lose the original survey date.
-        await this.windowService.createDailySurveyWindow(survey.samplingType, settings[invocationField]);
+        await this.windowService.createDailySurveyWindow(
+          survey.samplingType,
+          settings[invocationField]
+        );
       } else if (!settings[invocationField]) {
         await this.scheduleNextForSurvey(survey);
       }
@@ -143,13 +156,20 @@ export class DailySurveyTracker implements Tracker {
     return fallback;
   }
 
-  private getInvocationField(samplingType: DailySurveySamplingType): 'nextDailySurveyMorningInvocation' | 'nextDailySurveyEveningInvocation' {
+  private getInvocationField(
+    samplingType: DailySurveySamplingType
+  ): 'nextDailySurveyMorningInvocation' | 'nextDailySurveyEveningInvocation' {
     if (samplingType === 'morning') return 'nextDailySurveyMorningInvocation';
     if (samplingType === 'evening') return 'nextDailySurveyEveningInvocation';
     throw new Error(`Unknown samplingType: ${samplingType}`);
   }
 
-  private getPostponedUntilField(samplingType: DailySurveySamplingType): 'postponedDailySurveyMorningUntil' | 'postponedDailySurveyEveningUntil' {
+  /**
+   * Returns the Settings column that stores the postponed-until timestamp for the given daily survey type.
+   */
+  private getPostponedUntilField(
+    samplingType: DailySurveySamplingType
+  ): 'postponedDailySurveyMorningUntil' | 'postponedDailySurveyEveningUntil' {
     if (samplingType === 'morning') return 'postponedDailySurveyMorningUntil';
     if (samplingType === 'evening') return 'postponedDailySurveyEveningUntil';
     throw new Error(`Unknown samplingType: ${samplingType}`);
@@ -163,7 +183,10 @@ export class DailySurveyTracker implements Tracker {
     return compare < today;
   }
 
-  public async complete(samplingType: DailySurveySamplingType, scheduledDate?: Date | null): Promise<void> {
+  public async complete(
+    samplingType: DailySurveySamplingType,
+    scheduledDate?: Date | null
+  ): Promise<void> {
     this.openSurveyKeys.delete(samplingType);
 
     if (!scheduledDate) {
@@ -182,7 +205,9 @@ export class DailySurveyTracker implements Tracker {
     const settings: Settings = await Settings.findOneBy({ onlyOneEntityShouldExist: 1 });
     const scheduledDate = settings[this.getInvocationField(samplingType)];
     if (scheduledDate && this.isBeforeToday(scheduledDate)) {
-      LOG.info(`Daily survey (${samplingType}) was scheduled on a previous day and cannot be postponed`);
+      LOG.info(
+        `Daily survey (${samplingType}) was scheduled on a previous day and cannot be postponed`
+      );
       return false;
     }
 

--- a/src/electron/src/utils/Commands.ts
+++ b/src/electron/src/utils/Commands.ts
@@ -59,6 +59,7 @@ type Commands = {
   createDailySurveyResponses: (
     promptedAt: Date,
     samplingType: DailySurveySamplingType,
+    scheduledDate: Date | null,
     responses: DailySurveyResponseInput[]
   ) => Promise<void>;
   resizeDailySurveyWindow: (height: number) => void;

--- a/src/electron/src/views/DailySurveyView.vue
+++ b/src/electron/src/views/DailySurveyView.vue
@@ -22,7 +22,14 @@ const language =
   'en';
 
 const promptedAt = new Date();
-const isLateSubmission = scheduledDate && (promptedAt.getTime() - scheduledDate.getTime()) > 12 * 60 * 60 * 1000;
+const isSurveyFromPreviousDay = computed(() => {
+  if (!scheduledDate) return false;
+  const today = new Date(promptedAt);
+  today.setHours(0, 0, 0, 0);
+  const scheduledDay = new Date(scheduledDate);
+  scheduledDay.setHours(0, 0, 0, 0);
+  return scheduledDay < today;
+});
 const scheduledDateString = scheduledDate
   ? new Intl.DateTimeFormat(language, { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }).format(scheduledDate)
   : '';
@@ -89,7 +96,7 @@ async function submitSurvey() {
       };
     });
 
-    await typedIpcRenderer.invoke('createDailySurveyResponses', promptedAt, samplingType, responseInputs);
+    await typedIpcRenderer.invoke('createDailySurveyResponses', promptedAt, samplingType, scheduledDate, responseInputs);
     await typedIpcRenderer.invoke('closeDailySurveyWindow', false);
   } catch (error) {
     console.error('Error submitting daily survey', error);
@@ -109,7 +116,7 @@ async function skipSurvey() {
       skipped: true
     }));
 
-    await typedIpcRenderer.invoke('createDailySurveyResponses', promptedAt, samplingType, responseInputs);
+    await typedIpcRenderer.invoke('createDailySurveyResponses', promptedAt, samplingType, scheduledDate, responseInputs);
     await typedIpcRenderer.invoke('closeDailySurveyWindow', true);
   } catch (error) {
     console.error('Error skipping daily survey', error);
@@ -131,13 +138,15 @@ async function postpone(minutes: number) {
     </div>
 
     <div class="postpone-bar">
+      <template v-if="!isSurveyFromPreviousDay">
       <button class="postpone-button" :disabled="isSubmitting" @click="postpone(5)">Remind me again in 5 minutes</button>
       <button class="postpone-button" :disabled="isSubmitting" @click="postpone(15)">Remind me again in 15 minutes</button>
       <button class="postpone-button" :disabled="isSubmitting" @click="postpone(60)">Remind me again in 60 minutes</button>
+      </template>
       <button class="postpone-button" :disabled="isSubmitting" @click="skipSurvey()">Skip</button>
     </div>
 
-    <div v-if="isLateSubmission" class="late-notice">
+    <div v-if="isSurveyFromPreviousDay" class="late-notice">
       This survey was originally scheduled for {{ scheduledDateString }}.
     </div>
 


### PR DESCRIPTION
# Fix Daily Survey Reopening for Missed Days (Closes #525)

## Description

Fixes a bug where an unanswered daily survey from a previous day could reopen later with the wrong date. The original scheduled date is now preserved until the user saves or skips the survey.

### Changes Made

- Keep the original daily survey date until Save or Skip
- Store postponements separately from the scheduled survey date
- Schedule the next survey only after Save or Skip
- Hide “Remind me again…” buttons for previous-day surveys
- Keep Skip available for previous-day surveys
- Add a backend guard against postponing previous-day surveys

## Testing

- Manually tested an overdue survey from two days ago
- Confirmed the original date was shown
- Confirmed postpone buttons were hidden
- Confirmed Skip advanced to the next valid survey

Closes #525