### PR TITLE
[#510] Refine retrospection timeline hover details

### DIFF
--- a/src/electron/electron/main/__tests__/RetrospectionService.test.ts
+++ b/src/electron/electron/main/__tests__/RetrospectionService.test.ts
@@ -1,6 +1,17 @@
 import { expect, jest, test } from '@jest/globals';
 
 jest.unstable_mockModule('electron', () => ({
+  app: {
+    getFileIcon: jest.fn()
+  },
+  nativeImage: {
+    createFromPath: jest.fn(() => ({
+      isEmpty: () => true,
+      resize: () => ({
+        toDataURL: () => ''
+      })
+    }))
+  },
   default: {
     app: {
       isPackaged: false

--- a/src/electron/electron/main/services/RetrospectionService.ts
+++ b/src/electron/electron/main/services/RetrospectionService.ts
@@ -3,6 +3,7 @@ import { WindowActivityEntity } from '../entities/WindowActivityEntity';
 import { getMainLogger } from '../../config/Logger';
 import { Activity } from '../../../src/utils/retrospection/types';
 import { getProcessIconDataUrl } from './utils/AppIconHelper';
+import { getOverlapDurationMs } from './utils/helpers';
 
 const LOG = getMainLogger('RetrospectionService');
 
@@ -689,8 +690,10 @@ function isRelevantTopItem(session: ActivitySessions): boolean {
   );
 }
 
-// Short display label shown inside the tooltip row; keeps paths/domains compact.
-function getTimelineHoverTitle(activity: WindowActivityEntity): string | null {
+/**
+ * Returns the short display label shown inside a timeline tooltip row.
+ */
+function getShortTimelineHoverTitle(activity: WindowActivityEntity): string | null {
   const cleanedTitle = cleanWindowTitle(
     activity.windowTitle,
     activity.processName,
@@ -703,8 +706,10 @@ function getTimelineHoverTitle(activity: WindowActivityEntity): string | null {
   );
 }
 
-// Longer hover title for the row's native browser tooltip; keeps ellipses for shortened paths.
-function getTimelineHoverTooltipTitle(activity: WindowActivityEntity, title: string): string {
+/**
+ * Returns the longer native tooltip label for a timeline tooltip row.
+ */
+function getLongTimelineHoverTitle(activity: WindowActivityEntity, fallbackTitle: string): string {
   return (
     cleanWindowTitle(
       activity.windowTitle,
@@ -712,7 +717,7 @@ function getTimelineHoverTooltipTitle(activity: WindowActivityEntity, title: str
       activity.url,
       true,
       activity.activity
-    ) || title
+    ) || fallbackTitle
   );
 }
 
@@ -724,12 +729,12 @@ async function addWindowActivityDetailSpan(
   activeMinutesSet: Set<number>,
   date: Date
 ) {
-  const title = getTimelineHoverTitle(activity);
+  const title = getShortTimelineHoverTitle(activity);
   if (!title || to.getTime() <= from.getTime()) {
     return;
   }
 
-  const tooltipTitle = getTimelineHoverTooltipTitle(activity, title);
+  const tooltipTitle = getLongTimelineHoverTitle(activity, title);
   const iconDataUrl = await getProcessIconDataUrl(activity.processPath, activity.processName);
   getActiveMinuteSpans(from, to, activeMinutesSet, date).forEach((span) => {
     spans.push({
@@ -784,19 +789,6 @@ async function getWindowActivityDetailSpans(date: Date): Promise<WindowActivityD
   }
 
   return spans;
-}
-
-function getOverlapDurationMs(
-  firstStart: Date,
-  firstEnd: Date,
-  secondStart: Date,
-  secondEnd: Date
-): number {
-  return Math.max(
-    0,
-    Math.min(firstEnd.getTime(), secondEnd.getTime()) -
-      Math.max(firstStart.getTime(), secondStart.getTime())
-  );
 }
 
 function addTimelineHoverDetailsToSessions(

--- a/src/electron/electron/main/services/RetrospectionService.ts
+++ b/src/electron/electron/main/services/RetrospectionService.ts
@@ -2,9 +2,7 @@ import { UserInputEntity } from '../entities/UserInputEntity';
 import { WindowActivityEntity } from '../entities/WindowActivityEntity';
 import { getMainLogger } from '../../config/Logger';
 import { Activity } from '../../../src/utils/retrospection/types';
-import { app, nativeImage } from 'electron';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import path from 'node:path';
+import { getProcessIconDataUrl } from './utils/AppIconHelper';
 
 const LOG = getMainLogger('RetrospectionService');
 
@@ -45,8 +43,6 @@ interface WindowActivityDetailSpan {
   iconDataUrl?: string;
 }
 
-const APP_ICON_DATA_URL_CACHE = new Map<string, Promise<string | undefined>>();
-const APP_ICON_SIZE = 16;
 const TIMELINE_HOVER_DETAIL_LIMIT = 4;
 const MIN_TIMELINE_HOVER_DETAIL_DURATION_MS = 60_000;
 
@@ -693,6 +689,7 @@ function isRelevantTopItem(session: ActivitySessions): boolean {
   );
 }
 
+// Short display label shown inside the tooltip row; keeps paths/domains compact.
 function getTimelineHoverTitle(activity: WindowActivityEntity): string | null {
   const cleanedTitle = cleanWindowTitle(
     activity.windowTitle,
@@ -706,6 +703,7 @@ function getTimelineHoverTitle(activity: WindowActivityEntity): string | null {
   );
 }
 
+// Longer hover title for the row's native browser tooltip; keeps ellipses for shortened paths.
 function getTimelineHoverTooltipTitle(activity: WindowActivityEntity, title: string): string {
   return (
     cleanWindowTitle(
@@ -716,165 +714,6 @@ function getTimelineHoverTooltipTitle(activity: WindowActivityEntity, title: str
       activity.activity
     ) || title
   );
-}
-
-function normalizeIconName(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
-}
-
-function getMacAppBundlePath(processPath: string | null): string | null {
-  if (!processPath) {
-    return null;
-  }
-
-  const appBundleMatch = processPath.match(/^(.+?\.app)(?:\/|$)/);
-  return appBundleMatch?.[1] || null;
-}
-
-function getPersonalAnalyticsIconDataUrl(): string | undefined {
-  const iconPath = path.join(
-    process.env.VITE_PUBLIC || process.env.DIST || '',
-    'IconColored@2x.png'
-  );
-  return getIconDataUrlFromPath(iconPath);
-}
-
-function getPlistIconFileName(infoPlistPath: string): string | undefined {
-  if (!existsSync(infoPlistPath)) {
-    return undefined;
-  }
-
-  try {
-    const infoPlist = readFileSync(infoPlistPath, 'utf8');
-    const iconMatch = infoPlist.match(/<key>CFBundleIconFile<\/key>\s*<string>([^<]+)<\/string>/);
-    return iconMatch?.[1];
-  } catch (error) {
-    LOG.debug('Could not read app icon plist', infoPlistPath, error);
-    return undefined;
-  }
-}
-
-function getIconDataUrlFromPath(iconPath: string | undefined): string | undefined {
-  if (!iconPath || !existsSync(iconPath)) {
-    return undefined;
-  }
-
-  const icon = nativeImage.createFromPath(iconPath);
-  if (icon.isEmpty()) {
-    return undefined;
-  }
-
-  return icon.resize({ width: APP_ICON_SIZE, height: APP_ICON_SIZE }).toDataURL();
-}
-
-function getBundleResourceIconDataUrl(
-  appBundlePath: string,
-  processName: string | null
-): string | undefined {
-  const resourcesPath = path.join(appBundlePath, 'Contents', 'Resources');
-  if (!existsSync(resourcesPath)) {
-    return undefined;
-  }
-
-  const resourceFiles = readdirSync(resourcesPath).filter((file) => /\.(?:icns|png)$/i.test(file));
-  const normalizedProcessName = processName ? normalizeIconName(processName) : '';
-  const processSpecificFiles = normalizedProcessName
-    ? resourceFiles.filter((file) => {
-        const normalizedFile = normalizeIconName(path.parse(file).name);
-        return (
-          normalizedFile.includes(normalizedProcessName) && !normalizedFile.includes('template')
-        );
-      })
-    : [];
-
-  const plistIconFile = getPlistIconFileName(path.join(appBundlePath, 'Contents', 'Info.plist'));
-  const plistIconCandidates = plistIconFile
-    ? [
-        plistIconFile,
-        path.extname(plistIconFile) ? plistIconFile : `${plistIconFile}.icns`,
-        path.extname(plistIconFile) ? plistIconFile : `${plistIconFile}.png`
-      ]
-    : [];
-
-  const candidateFiles = [
-    ...processSpecificFiles,
-    'app.icns',
-    'icon.icns',
-    'icon.png',
-    'Icon.icns',
-    'Icon.png',
-    'AppIcon.icns',
-    'AppIcon.png',
-    ...plistIconCandidates,
-    ...resourceFiles.filter((file) => !normalizeIconName(file).includes('template'))
-  ];
-
-  const seenFiles = new Set<string>();
-  for (const file of candidateFiles) {
-    if (seenFiles.has(file)) {
-      continue;
-    }
-    seenFiles.add(file);
-
-    const iconDataUrl = getIconDataUrlFromPath(path.join(resourcesPath, file));
-    if (iconDataUrl) {
-      return iconDataUrl;
-    }
-  }
-
-  return undefined;
-}
-
-async function getProcessIconDataUrl(
-  processPath: string | null,
-  processName: string | null
-): Promise<string | undefined> {
-  const cacheKey = `${processPath || ''}\u0000${processName || ''}`;
-  const cachedIcon = APP_ICON_DATA_URL_CACHE.get(cacheKey);
-  if (cachedIcon) {
-    return cachedIcon;
-  }
-
-  const iconPromise = (async () => {
-    const appBundlePath = getMacAppBundlePath(processPath);
-    if (
-      processName === 'Electron' &&
-      processPath?.includes('/PersonalAnalytics/') &&
-      processPath.includes('/node_modules/electron/')
-    ) {
-      const personalAnalyticsIcon = getPersonalAnalyticsIconDataUrl();
-      if (personalAnalyticsIcon) {
-        return personalAnalyticsIcon;
-      }
-    }
-
-    if (appBundlePath) {
-      const bundleIcon = getBundleResourceIconDataUrl(appBundlePath, processName);
-      if (bundleIcon) {
-        return bundleIcon;
-      }
-    }
-
-    if (!processPath) {
-      return undefined;
-    }
-
-    return app
-      .getFileIcon(appBundlePath || processPath, { size: 'small' })
-      .then((icon) => {
-        if (icon.isEmpty()) {
-          return undefined;
-        }
-        return icon.resize({ width: APP_ICON_SIZE, height: APP_ICON_SIZE }).toDataURL();
-      })
-      .catch((error) => {
-        LOG.debug('Could not load app icon for retrospection timeline', processPath, error);
-        return undefined;
-      });
-  })();
-
-  APP_ICON_DATA_URL_CACHE.set(cacheKey, iconPromise);
-  return iconPromise;
 }
 
 async function addWindowActivityDetailSpan(

--- a/src/electron/electron/main/services/RetrospectionService.ts
+++ b/src/electron/electron/main/services/RetrospectionService.ts
@@ -47,6 +47,8 @@ interface WindowActivityDetailSpan {
 
 const APP_ICON_DATA_URL_CACHE = new Map<string, Promise<string | undefined>>();
 const APP_ICON_SIZE = 16;
+const TIMELINE_HOVER_DETAIL_LIMIT = 4;
+const MIN_TIMELINE_HOVER_DETAIL_DURATION_MS = 60_000;
 
 // Mirrored from PA.WindowsActivityTracker/typescript/src/mappings/browsers.ts.
 // Used here to recognize browser processes without importing tracker source into the main bundle.
@@ -961,7 +963,7 @@ function getOverlapDurationMs(
 function addTimelineHoverDetailsToSessions(
   activitySessions: ActivitySessions[],
   detailSpans: WindowActivityDetailSpan[],
-  limit = 3
+  limit = TIMELINE_HOVER_DETAIL_LIMIT
 ): ActivitySessions[] {
   return activitySessions.map((activitySession) => {
     const sessions = activitySession.sessions.map((session) => {
@@ -998,7 +1000,9 @@ function addTimelineHoverDetailsToSessions(
         }
       });
 
-      const details = Array.from(detailsByKey.values()).sort((a, b) => b.durationMs - a.durationMs);
+      const details = Array.from(detailsByKey.values())
+        .filter((detail) => detail.durationMs >= MIN_TIMELINE_HOVER_DETAIL_DURATION_MS)
+        .sort((a, b) => b.durationMs - a.durationMs);
 
       return {
         ...session,

--- a/src/electron/electron/main/services/RetrospectionService.ts
+++ b/src/electron/electron/main/services/RetrospectionService.ts
@@ -2,6 +2,9 @@ import { UserInputEntity } from '../entities/UserInputEntity';
 import { WindowActivityEntity } from '../entities/WindowActivityEntity';
 import { getMainLogger } from '../../config/Logger';
 import { Activity } from '../../../src/utils/retrospection/types';
+import { app, nativeImage } from 'electron';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
 
 const LOG = getMainLogger('RetrospectionService');
 
@@ -9,6 +12,8 @@ export interface TimeActive {
   from: Date;
   to: Date;
   duration: number;
+  details?: TimelineHoverDetail[];
+  hiddenDetailCount?: number;
 }
 
 export interface ActivitySessions {
@@ -20,6 +25,28 @@ export interface ActivitySessions {
 }
 
 type WindowActivitySessionKeySelector = (activity: WindowActivityEntity) => string | null;
+
+export interface TimelineHoverDetail {
+  title: string;
+  appName?: string | null;
+  durationMs: number;
+  tooltipTitle?: string;
+  activity?: string;
+  iconDataUrl?: string;
+}
+
+interface WindowActivityDetailSpan {
+  from: Date;
+  to: Date;
+  activity: string;
+  title: string;
+  appName?: string | null;
+  tooltipTitle?: string;
+  iconDataUrl?: string;
+}
+
+const APP_ICON_DATA_URL_CACHE = new Map<string, Promise<string | undefined>>();
+const APP_ICON_SIZE = 16;
 
 // Mirrored from PA.WindowsActivityTracker/typescript/src/mappings/browsers.ts.
 // Used here to recognize browser processes without importing tracker source into the main bundle.
@@ -216,6 +243,57 @@ function addActivitySessionEntry(
   map.set(key, entry);
 }
 
+function getActiveMinuteSpans(
+  from: Date,
+  to: Date,
+  activeMinutesSet: Set<number>,
+  date: Date
+): TimeActive[] {
+  if (to.getTime() <= from.getTime()) {
+    return [];
+  }
+
+  const spans: TimeActive[] = [];
+  const addSpan = (spanFrom: Date, spanTo: Date) => {
+    if (spanTo.getTime() <= spanFrom.getTime()) {
+      return;
+    }
+    spans.push({
+      from: spanFrom,
+      to: spanTo,
+      duration: spanTo.getTime() - spanFrom.getTime()
+    });
+  };
+
+  const startMinute = getMinuteOfDay(from);
+  const endMinute = getMinuteOfDay(to);
+
+  let sessionStart = from;
+  if (startMinute + 1 < endMinute) {
+    let inSession = true;
+    for (let m = startMinute; m < endMinute; m++) {
+      if (!activeMinutesSet.has(m) && inSession) {
+        inSession = false;
+        let sessionEnd = getDateFromMinuteOfDay(m, date);
+        sessionEnd = sessionEnd.getTime() > to.getTime() ? to : sessionEnd;
+        addSpan(sessionStart, sessionEnd);
+      } else if (!activeMinutesSet.has(m) && !inSession) {
+        sessionStart = getDateFromMinuteOfDay(m, date);
+      } else if (activeMinutesSet.has(m) && !inSession) {
+        sessionStart = getDateFromMinuteOfDay(m, date);
+        inSession = true;
+      } else if (activeMinutesSet.has(m) && inSession) {
+        // session is continuously active
+      } else {
+        LOG.error('Unexpected state in session reconstruction');
+      }
+    }
+  }
+
+  addSpan(sessionStart, to);
+  return spans;
+}
+
 /**
  * Adds one tracked window span to the aggregate map, but only for minutes where user input exists.
  *
@@ -240,33 +318,9 @@ function addSessionWithActiveMinuteSplits(
     return;
   }
 
-  const startMinute = getMinuteOfDay(from);
-  const endMinute = getMinuteOfDay(to);
-
-  let sessionStart = from;
-  if (startMinute + 1 < endMinute) {
-    // Split a window span when user-input data shows inactivity inside it.
-    let inSession = true;
-    for (let m = startMinute; m < endMinute; m++) {
-      if (!activeMinutesSet.has(m) && inSession) {
-        inSession = false;
-        let sessionEnd = getDateFromMinuteOfDay(m, date);
-        sessionEnd = sessionEnd.getTime() > to.getTime() ? to : sessionEnd;
-        addEntry(sessionKey, sessionStart, sessionEnd, activity);
-      } else if (!activeMinutesSet.has(m) && !inSession) {
-        sessionStart = getDateFromMinuteOfDay(m, date);
-      } else if (activeMinutesSet.has(m) && !inSession) {
-        sessionStart = getDateFromMinuteOfDay(m, date);
-        inSession = true;
-      } else if (activeMinutesSet.has(m) && inSession) {
-        // session is continuously active
-      } else {
-        LOG.error('Unexpected state in session reconstruction');
-      }
-    }
-  }
-
-  addEntry(sessionKey, sessionStart, to, activity);
+  getActiveMinuteSpans(from, to, activeMinutesSet, date).forEach((span) => {
+    addEntry(sessionKey, span.from, span.to, activity);
+  });
 }
 
 /**
@@ -637,6 +691,329 @@ function isRelevantTopItem(session: ActivitySessions): boolean {
   );
 }
 
+function getTimelineHoverTitle(activity: WindowActivityEntity): string | null {
+  const cleanedTitle = cleanWindowTitle(
+    activity.windowTitle,
+    activity.processName,
+    activity.url,
+    false,
+    activity.activity
+  );
+  return (
+    cleanedTitle || getDomainFromUrl(activity.url) || activity.processName || activity.activity
+  );
+}
+
+function getTimelineHoverTooltipTitle(activity: WindowActivityEntity, title: string): string {
+  return (
+    cleanWindowTitle(
+      activity.windowTitle,
+      activity.processName,
+      activity.url,
+      true,
+      activity.activity
+    ) || title
+  );
+}
+
+function normalizeIconName(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function getMacAppBundlePath(processPath: string | null): string | null {
+  if (!processPath) {
+    return null;
+  }
+
+  const appBundleMatch = processPath.match(/^(.+?\.app)(?:\/|$)/);
+  return appBundleMatch?.[1] || null;
+}
+
+function getPersonalAnalyticsIconDataUrl(): string | undefined {
+  const iconPath = path.join(
+    process.env.VITE_PUBLIC || process.env.DIST || '',
+    'IconColored@2x.png'
+  );
+  return getIconDataUrlFromPath(iconPath);
+}
+
+function getPlistIconFileName(infoPlistPath: string): string | undefined {
+  if (!existsSync(infoPlistPath)) {
+    return undefined;
+  }
+
+  try {
+    const infoPlist = readFileSync(infoPlistPath, 'utf8');
+    const iconMatch = infoPlist.match(/<key>CFBundleIconFile<\/key>\s*<string>([^<]+)<\/string>/);
+    return iconMatch?.[1];
+  } catch (error) {
+    LOG.debug('Could not read app icon plist', infoPlistPath, error);
+    return undefined;
+  }
+}
+
+function getIconDataUrlFromPath(iconPath: string | undefined): string | undefined {
+  if (!iconPath || !existsSync(iconPath)) {
+    return undefined;
+  }
+
+  const icon = nativeImage.createFromPath(iconPath);
+  if (icon.isEmpty()) {
+    return undefined;
+  }
+
+  return icon.resize({ width: APP_ICON_SIZE, height: APP_ICON_SIZE }).toDataURL();
+}
+
+function getBundleResourceIconDataUrl(
+  appBundlePath: string,
+  processName: string | null
+): string | undefined {
+  const resourcesPath = path.join(appBundlePath, 'Contents', 'Resources');
+  if (!existsSync(resourcesPath)) {
+    return undefined;
+  }
+
+  const resourceFiles = readdirSync(resourcesPath).filter((file) => /\.(?:icns|png)$/i.test(file));
+  const normalizedProcessName = processName ? normalizeIconName(processName) : '';
+  const processSpecificFiles = normalizedProcessName
+    ? resourceFiles.filter((file) => {
+        const normalizedFile = normalizeIconName(path.parse(file).name);
+        return (
+          normalizedFile.includes(normalizedProcessName) && !normalizedFile.includes('template')
+        );
+      })
+    : [];
+
+  const plistIconFile = getPlistIconFileName(path.join(appBundlePath, 'Contents', 'Info.plist'));
+  const plistIconCandidates = plistIconFile
+    ? [
+        plistIconFile,
+        path.extname(plistIconFile) ? plistIconFile : `${plistIconFile}.icns`,
+        path.extname(plistIconFile) ? plistIconFile : `${plistIconFile}.png`
+      ]
+    : [];
+
+  const candidateFiles = [
+    ...processSpecificFiles,
+    'app.icns',
+    'icon.icns',
+    'icon.png',
+    'Icon.icns',
+    'Icon.png',
+    'AppIcon.icns',
+    'AppIcon.png',
+    ...plistIconCandidates,
+    ...resourceFiles.filter((file) => !normalizeIconName(file).includes('template'))
+  ];
+
+  const seenFiles = new Set<string>();
+  for (const file of candidateFiles) {
+    if (seenFiles.has(file)) {
+      continue;
+    }
+    seenFiles.add(file);
+
+    const iconDataUrl = getIconDataUrlFromPath(path.join(resourcesPath, file));
+    if (iconDataUrl) {
+      return iconDataUrl;
+    }
+  }
+
+  return undefined;
+}
+
+async function getProcessIconDataUrl(
+  processPath: string | null,
+  processName: string | null
+): Promise<string | undefined> {
+  const cacheKey = `${processPath || ''}\u0000${processName || ''}`;
+  const cachedIcon = APP_ICON_DATA_URL_CACHE.get(cacheKey);
+  if (cachedIcon) {
+    return cachedIcon;
+  }
+
+  const iconPromise = (async () => {
+    const appBundlePath = getMacAppBundlePath(processPath);
+    if (
+      processName === 'Electron' &&
+      processPath?.includes('/PersonalAnalytics/') &&
+      processPath.includes('/node_modules/electron/')
+    ) {
+      const personalAnalyticsIcon = getPersonalAnalyticsIconDataUrl();
+      if (personalAnalyticsIcon) {
+        return personalAnalyticsIcon;
+      }
+    }
+
+    if (appBundlePath) {
+      const bundleIcon = getBundleResourceIconDataUrl(appBundlePath, processName);
+      if (bundleIcon) {
+        return bundleIcon;
+      }
+    }
+
+    if (!processPath) {
+      return undefined;
+    }
+
+    return app
+      .getFileIcon(appBundlePath || processPath, { size: 'small' })
+      .then((icon) => {
+        if (icon.isEmpty()) {
+          return undefined;
+        }
+        return icon.resize({ width: APP_ICON_SIZE, height: APP_ICON_SIZE }).toDataURL();
+      })
+      .catch((error) => {
+        LOG.debug('Could not load app icon for retrospection timeline', processPath, error);
+        return undefined;
+      });
+  })();
+
+  APP_ICON_DATA_URL_CACHE.set(cacheKey, iconPromise);
+  return iconPromise;
+}
+
+async function addWindowActivityDetailSpan(
+  spans: WindowActivityDetailSpan[],
+  activity: WindowActivityEntity,
+  from: Date,
+  to: Date,
+  activeMinutesSet: Set<number>,
+  date: Date
+) {
+  const title = getTimelineHoverTitle(activity);
+  if (!title || to.getTime() <= from.getTime()) {
+    return;
+  }
+
+  const tooltipTitle = getTimelineHoverTooltipTitle(activity, title);
+  const iconDataUrl = await getProcessIconDataUrl(activity.processPath, activity.processName);
+  getActiveMinuteSpans(from, to, activeMinutesSet, date).forEach((span) => {
+    spans.push({
+      from: span.from,
+      to: span.to,
+      activity: activity.activity,
+      title,
+      appName: activity.processName,
+      tooltipTitle,
+      iconDataUrl
+    });
+  });
+}
+
+async function getWindowActivityDetailSpans(date: Date): Promise<WindowActivityDetailSpan[]> {
+  const windowActivityToday = await getWindowActivities(date);
+  const activeMinutesSet = await getActiveMinutesSet(date);
+  const spans: WindowActivityDetailSpan[] = [];
+
+  let lastWindowActivity: WindowActivityEntity | undefined = undefined;
+  for (const activity of windowActivityToday) {
+    if (!activeMinutesSet.has(getMinuteOfDay(new Date(activity.ts)))) {
+      continue;
+    }
+
+    if (lastWindowActivity) {
+      await addWindowActivityDetailSpan(
+        spans,
+        lastWindowActivity,
+        new Date(lastWindowActivity.ts),
+        new Date(activity.ts),
+        activeMinutesSet,
+        date
+      );
+    }
+
+    lastWindowActivity = activity;
+  }
+
+  if (lastWindowActivity) {
+    const start = new Date(lastWindowActivity.ts);
+    const end = new Date(start);
+    end.setMinutes(end.getMinutes() + 1);
+    await addWindowActivityDetailSpan(
+      spans,
+      lastWindowActivity,
+      start,
+      end,
+      activeMinutesSet,
+      date
+    );
+  }
+
+  return spans;
+}
+
+function getOverlapDurationMs(
+  firstStart: Date,
+  firstEnd: Date,
+  secondStart: Date,
+  secondEnd: Date
+): number {
+  return Math.max(
+    0,
+    Math.min(firstEnd.getTime(), secondEnd.getTime()) -
+      Math.max(firstStart.getTime(), secondStart.getTime())
+  );
+}
+
+function addTimelineHoverDetailsToSessions(
+  activitySessions: ActivitySessions[],
+  detailSpans: WindowActivityDetailSpan[],
+  limit = 3
+): ActivitySessions[] {
+  return activitySessions.map((activitySession) => {
+    const sessions = activitySession.sessions.map((session) => {
+      const detailsByKey = new Map<string, TimelineHoverDetail>();
+
+      detailSpans.forEach((detailSpan) => {
+        if (detailSpan.activity !== activitySession.type) {
+          return;
+        }
+
+        const overlapDurationMs = getOverlapDurationMs(
+          session.from,
+          session.to,
+          detailSpan.from,
+          detailSpan.to
+        );
+        if (overlapDurationMs <= 0) {
+          return;
+        }
+
+        const detailKey = `${detailSpan.title}\u0000${detailSpan.appName || ''}`;
+        const existingDetail = detailsByKey.get(detailKey);
+        if (existingDetail) {
+          existingDetail.durationMs += overlapDurationMs;
+        } else {
+          detailsByKey.set(detailKey, {
+            title: detailSpan.title,
+            appName: detailSpan.appName,
+            tooltipTitle: detailSpan.tooltipTitle,
+            activity: detailSpan.activity,
+            iconDataUrl: detailSpan.iconDataUrl,
+            durationMs: overlapDurationMs
+          });
+        }
+      });
+
+      const details = Array.from(detailsByKey.values()).sort((a, b) => b.durationMs - a.durationMs);
+
+      return {
+        ...session,
+        details: details.slice(0, limit),
+        hiddenDetailCount: Math.max(0, details.length - limit)
+      };
+    });
+
+    return {
+      ...activitySession,
+      sessions
+    };
+  });
+}
+
 /**
  * finds the longest time period of the given day where user input was detected continuously
  * @returns the longest active time period
@@ -763,26 +1140,28 @@ export async function getActivitySessions(
   excludeUnspecificActivities = true
 ): Promise<ActivitySessions[]> {
   const sessions = await getWindowActivitySessionsByType('activity', date);
-  if (excludeUnspecificActivities) {
-    return sessions.filter((s) =>
-      [
-        'DevCode',
-        'DevDebug',
-        'DevReview',
-        'DevVc',
-        'Planning',
-        'ReadWriteDocument',
-        'Design',
-        'GenerativeAI',
-        'PlannedMeeting',
-        'Email',
-        'InstantMessaging',
-        'WorkRelatedBrowsing',
-        'WorkUnrelatedBrowsing',
-        'SocialMedia',
-        'FileManagement'
-      ].includes(s.type)
-    );
-  }
-  return sessions;
+  const filteredSessions = excludeUnspecificActivities
+    ? sessions.filter((s) =>
+        [
+          'DevCode',
+          'DevDebug',
+          'DevReview',
+          'DevVc',
+          'Planning',
+          'ReadWriteDocument',
+          'Design',
+          'GenerativeAI',
+          'PlannedMeeting',
+          'Email',
+          'InstantMessaging',
+          'WorkRelatedBrowsing',
+          'WorkUnrelatedBrowsing',
+          'SocialMedia',
+          'FileManagement'
+        ].includes(s.type)
+      )
+    : sessions;
+
+  const detailSpans = await getWindowActivityDetailSpans(date);
+  return addTimelineHoverDetailsToSessions(filteredSessions, detailSpans);
 }

--- a/src/electron/electron/main/services/utils/AppIconHelper.ts
+++ b/src/electron/electron/main/services/utils/AppIconHelper.ts
@@ -1,0 +1,170 @@
+import { app, nativeImage } from 'electron';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { getMainLogger } from '../../../config/Logger';
+
+const LOG = getMainLogger('AppIconHelper');
+const APP_ICON_DATA_URL_CACHE = new Map<string, Promise<string | undefined>>();
+const APP_ICON_SIZE = 16;
+
+function normalizeIconName(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function getMacAppBundlePath(processPath: string | null): string | null {
+  if (!processPath) {
+    return null;
+  }
+
+  const appBundleMatch = processPath.match(/^(.+?\.app)(?:\/|$)/);
+  return appBundleMatch?.[1] || null;
+}
+
+function getPersonalAnalyticsIconDataUrl(): string | undefined {
+  const iconPath = path.join(
+    process.env.VITE_PUBLIC || process.env.DIST || '',
+    'IconColored@2x.png'
+  );
+  return getIconDataUrlFromPath(iconPath);
+}
+
+function getPlistIconFileName(infoPlistPath: string): string | undefined {
+  if (!existsSync(infoPlistPath)) {
+    return undefined;
+  }
+
+  try {
+    const infoPlist = readFileSync(infoPlistPath, 'utf8');
+    const iconMatch = infoPlist.match(/<key>CFBundleIconFile<\/key>\s*<string>([^<]+)<\/string>/);
+    return iconMatch?.[1];
+  } catch (error) {
+    LOG.debug('Could not read app icon plist', infoPlistPath, error);
+    return undefined;
+  }
+}
+
+function getIconDataUrlFromPath(iconPath: string | undefined): string | undefined {
+  if (!iconPath || !existsSync(iconPath)) {
+    return undefined;
+  }
+
+  const icon = nativeImage.createFromPath(iconPath);
+  if (icon.isEmpty()) {
+    return undefined;
+  }
+
+  return icon.resize({ width: APP_ICON_SIZE, height: APP_ICON_SIZE }).toDataURL();
+}
+
+function getBundleResourceIconDataUrl(
+  appBundlePath: string,
+  processName: string | null
+): string | undefined {
+  const resourcesPath = path.join(appBundlePath, 'Contents', 'Resources');
+  if (!existsSync(resourcesPath)) {
+    return undefined;
+  }
+
+  const resourceFiles = readdirSync(resourcesPath).filter((file) => /\.(?:icns|png)$/i.test(file));
+  const normalizedProcessName = processName ? normalizeIconName(processName) : '';
+  const processSpecificFiles = normalizedProcessName
+    ? resourceFiles.filter((file) => {
+        const normalizedFile = normalizeIconName(path.parse(file).name);
+        return (
+          normalizedFile.includes(normalizedProcessName) && !normalizedFile.includes('template')
+        );
+      })
+    : [];
+
+  const plistIconFile = getPlistIconFileName(path.join(appBundlePath, 'Contents', 'Info.plist'));
+  const plistIconCandidates = plistIconFile
+    ? [
+        plistIconFile,
+        path.extname(plistIconFile) ? plistIconFile : `${plistIconFile}.icns`,
+        path.extname(plistIconFile) ? plistIconFile : `${plistIconFile}.png`
+      ]
+    : [];
+
+  const candidateFiles = [
+    ...processSpecificFiles,
+    'app.icns',
+    'icon.icns',
+    'icon.png',
+    'Icon.icns',
+    'Icon.png',
+    'AppIcon.icns',
+    'AppIcon.png',
+    ...plistIconCandidates,
+    ...resourceFiles.filter((file) => !normalizeIconName(file).includes('template'))
+  ];
+
+  const seenFiles = new Set<string>();
+  for (const file of candidateFiles) {
+    if (seenFiles.has(file)) {
+      continue;
+    }
+    seenFiles.add(file);
+
+    const iconDataUrl = getIconDataUrlFromPath(path.join(resourcesPath, file));
+    if (iconDataUrl) {
+      return iconDataUrl;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolves a local app icon for a tracked process and returns it as a small renderer-safe data URL.
+ */
+export async function getProcessIconDataUrl(
+  processPath: string | null,
+  processName: string | null
+): Promise<string | undefined> {
+  const cacheKey = `${processPath || ''}\u0000${processName || ''}`;
+  const cachedIcon = APP_ICON_DATA_URL_CACHE.get(cacheKey);
+  if (cachedIcon) {
+    return cachedIcon;
+  }
+
+  const iconPromise = (async () => {
+    const appBundlePath = getMacAppBundlePath(processPath);
+    if (
+      processName === 'Electron' &&
+      processPath?.includes('/PersonalAnalytics/') &&
+      processPath.includes('/node_modules/electron/')
+    ) {
+      const personalAnalyticsIcon = getPersonalAnalyticsIconDataUrl();
+      if (personalAnalyticsIcon) {
+        return personalAnalyticsIcon;
+      }
+    }
+
+    if (appBundlePath) {
+      const bundleIcon = getBundleResourceIconDataUrl(appBundlePath, processName);
+      if (bundleIcon) {
+        return bundleIcon;
+      }
+    }
+
+    if (!processPath) {
+      return undefined;
+    }
+
+    return app
+      .getFileIcon(appBundlePath || processPath, { size: 'small' })
+      .then((icon) => {
+        if (icon.isEmpty()) {
+          return undefined;
+        }
+        return icon.resize({ width: APP_ICON_SIZE, height: APP_ICON_SIZE }).toDataURL();
+      })
+      .catch((error) => {
+        LOG.debug('Could not load app icon', processPath, error);
+        return undefined;
+      });
+  })();
+
+  APP_ICON_DATA_URL_CACHE.set(cacheKey, iconPromise);
+  return iconPromise;
+}

--- a/src/electron/electron/main/services/utils/helpers.ts
+++ b/src/electron/electron/main/services/utils/helpers.ts
@@ -17,10 +17,23 @@ export function generateAlphaNumericString(length: number = 0): string {
     throw new Error('Length must be greater than 0');
   }
 
-  const characters = 'ABCDEFGHJKLMNPQRSTUVWXYZ123456789'; // removed 0, O, I and l from options to avoid participant IDs that are ambiguous 
+  const characters = 'ABCDEFGHJKLMNPQRSTUVWXYZ123456789'; // removed 0, O, I and l from options to avoid participant IDs that are ambiguous
   let result = '';
   for (let i = 0; i < length; i++) {
     result += characters.charAt(Math.floor(Math.random() * characters.length));
   }
   return result;
+}
+
+export function getOverlapDurationMs(
+  firstStart: Date,
+  firstEnd: Date,
+  secondStart: Date,
+  secondEnd: Date
+): number {
+  return Math.max(
+    0,
+    Math.min(firstEnd.getTime(), secondEnd.getTime()) -
+      Math.max(firstStart.getTime(), secondStart.getTime())
+  );
 }

--- a/src/electron/src/components/StackedBarChart.vue
+++ b/src/electron/src/components/StackedBarChart.vue
@@ -14,6 +14,8 @@ import * as d3 from 'd3';
 import { Color } from '../utils/retrospection/types';
 import {
   ACTIVITY_LABELS,
+  clamp,
+  escapeHtml,
   getActivityGroupFromActivityName,
   getBarColorFromDataPoint,
   msToReadableFormat,
@@ -126,15 +128,6 @@ function getActiveTaskTotalTimeSpentPerActivityGroupArray() {
   return activeTaskTotalTimeSpentPerActivityGroup;
 }
 
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
-
 function shouldShowAppName(detail: TimelineHoverDetail): boolean {
   if (!detail.appName) {
     return false;
@@ -211,10 +204,6 @@ function renderTooltipDetails(dataPoint: ChartDataPoint): string {
       ${hiddenRow}
     </ol>
   `;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
 }
 
 function positionTooltip(event: MouseEvent, barBoundingRect: DOMRect) {

--- a/src/electron/src/components/StackedBarChart.vue
+++ b/src/electron/src/components/StackedBarChart.vue
@@ -158,8 +158,22 @@ function renderTooltipDetailIcon(detail: TimelineHoverDetail): string {
   `;
 }
 
+function renderTooltipDuration(durationInMs: number): string {
+  const totalMinutes = Math.round(durationInMs / 60000);
+  if (totalMinutes < 1) {
+    return '< 1 min';
+  }
+  if (totalMinutes < 60) {
+    return `${totalMinutes} min`;
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes ? `${hours} h ${minutes} min` : `${hours} h`;
+}
+
 function renderTooltipDetail(detail: TimelineHoverDetail): string {
-  const duration = msToReadableFormat(detail.durationMs, false, false);
+  const duration = renderTooltipDuration(detail.durationMs);
   const title = escapeHtml(detail.title);
   const tooltipTitle = escapeHtml(detail.tooltipTitle || detail.title);
   const appName = detail.appName ? escapeHtml(detail.appName) : '';
@@ -181,11 +195,12 @@ function renderTooltipDetail(detail: TimelineHoverDetail): string {
 }
 
 function renderTooltipDetails(dataPoint: ChartDataPoint): string {
-  if (!dataPoint.details?.length) {
+  const details = dataPoint.details?.filter((detail) => detail.durationMs >= 60000) || [];
+  if (!details.length) {
     return '';
   }
 
-  const detailRows = dataPoint.details.map(renderTooltipDetail).join('');
+  const detailRows = details.map(renderTooltipDetail).join('');
   const hiddenDetailCount = dataPoint.hiddenDetailCount || 0;
   const hiddenRow =
     hiddenDetailCount > 0 ? `<li style="color: #64748b;">+ ${hiddenDetailCount} more</li>` : '';
@@ -291,17 +306,12 @@ function buildChart() {
     })
     .on('mousemove', function (this: SVGRectElement, event: MouseEvent, d: unknown) {
       const dataPoint = d as ChartDataPoint;
-      const durationInMinutes = msToReadableFormat(
-        dataPoint.end.getTime() - dataPoint.start.getTime(),
-        false,
-        false
-      );
+      const duration = renderTooltipDuration(dataPoint.end.getTime() - dataPoint.start.getTime());
 
       const barBoundingRect = this.getBoundingClientRect();
 
       const tooltipContent = `
-        <div class="text-${dataPoint.color}" style="font-weight: 600; text-align: center;">${ACTIVITY_LABELS[getActivityGroupFromActivityName(dataPoint.activity)]}</div>
-        <div style="text-align: center;">${timeFormat(dataPoint.start)} - ${timeFormat(dataPoint.end)} (${durationInMinutes})</div>
+        <div class="text-${dataPoint.color}" style="font-weight: 600; text-align: center;">${ACTIVITY_LABELS[getActivityGroupFromActivityName(dataPoint.activity)]} ${timeFormat(dataPoint.start)} - ${timeFormat(dataPoint.end)} (${duration})</div>
         ${renderTooltipDetails(dataPoint)}
       `;
 

--- a/src/electron/src/components/StackedBarChart.vue
+++ b/src/electron/src/components/StackedBarChart.vue
@@ -311,7 +311,10 @@ function buildChart() {
       const barBoundingRect = this.getBoundingClientRect();
 
       const tooltipContent = `
-        <div class="text-${dataPoint.color}" style="font-weight: 600; text-align: center;">${ACTIVITY_LABELS[getActivityGroupFromActivityName(dataPoint.activity)]} ${timeFormat(dataPoint.start)} - ${timeFormat(dataPoint.end)} (${duration})</div>
+        <div style="text-align: center;">
+          <span class="text-${dataPoint.color}" style="font-weight: 600;">${ACTIVITY_LABELS[getActivityGroupFromActivityName(dataPoint.activity)]}</span>
+          <span>${timeFormat(dataPoint.start)} - ${timeFormat(dataPoint.end)} (${duration})</span>
+        </div>
         ${renderTooltipDetails(dataPoint)}
       `;
 
@@ -485,6 +488,8 @@ function rebuildChartWithAnimation() {
 <style scoped>
 #tooltip {
   position: absolute;
+  font-size: 12px;
+  line-height: 1.35;
   text-align: left;
   width: auto;
   max-width: 360px;

--- a/src/electron/src/components/StackedBarChart.vue
+++ b/src/electron/src/components/StackedBarChart.vue
@@ -1,23 +1,29 @@
 <template>
-  <div id="tooltip"
-      class="bg-white text-gray-700 border border-gray-200 dark:bg-neutral-800 dark:text-neutral-300 dark:border-transparent p-2 rounded opacity-0 transition-opacity ease-in-out duration-300 shadow-lg dark:shadow-neutral-800/80">
+  <div
+    id="tooltip"
+    class="rounded border border-gray-200 bg-white p-2 text-gray-700 opacity-0 shadow-lg transition-opacity duration-300 ease-in-out dark:border-transparent dark:bg-neutral-800 dark:text-neutral-300 dark:shadow-neutral-800/80"
+  >
     <span id="content"></span>
   </div>
   <svg ref="chart" :width="svgWidth" :height="svgHeight"></svg>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, computed, watch } from 'vue'
-import * as d3 from 'd3'
-import { Color } from '../utils/retrospection/types'
+import { ref, onMounted, onUnmounted, computed, watch } from 'vue';
+import * as d3 from 'd3';
+import { Color } from '../utils/retrospection/types';
 import {
   ACTIVITY_LABELS,
   getActivityGroupFromActivityName,
   getBarColorFromDataPoint,
   msToReadableFormat,
   TW_CLASS_ACTIVITY_MAPPINGS
-} from '../utils/retrospection/utils'
-import { DataPointType, ChartDataPoint } from '../utils/retrospection/types'
+} from '../utils/retrospection/utils';
+import {
+  DataPointType,
+  ChartDataPoint,
+  type TimelineHoverDetail
+} from '../utils/retrospection/types';
 
 const props = defineProps({
   data: {
@@ -28,7 +34,7 @@ const props = defineProps({
     type: String,
     required: true,
     validator: (value: string) => {
-      return ['WINDOW_ACTIVITY'].includes(value)
+      return ['WINDOW_ACTIVITY'].includes(value);
     }
   },
   startDate: {
@@ -39,94 +45,201 @@ const props = defineProps({
     type: Number,
     required: true
   }
-})
+});
 
-const svgWidth = 760
-const chart = ref<SVGElement | null>()
-const chartSelectedLegendItem = ref<string | null>()
-const darkMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-const isDark = ref(darkMediaQuery.matches)
+const svgWidth = 760;
+const chart = ref<SVGElement | null>();
+const chartSelectedLegendItem = ref<string | null>();
+const darkMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+const isDark = ref(darkMediaQuery.matches);
 
 function onThemeChange(e: MediaQueryListEvent) {
-  isDark.value = e.matches
-  d3.select(chart.value!).selectAll('*').remove()
-  buildChart()
+  isDark.value = e.matches;
+  d3.select(chart.value!).selectAll('*').remove();
+  buildChart();
 }
 
-const chartStartDate = ref<number>()
-const chartEndDate = ref<number>()
+const chartStartDate = ref<number>();
+const chartEndDate = ref<number>();
 
 onMounted(() => {
-  darkMediaQuery.addEventListener('change', onThemeChange)
-  const minStartTime = new Date(props.startDate).setHours(0, 0, 0, 0)
-  const maxEndTime = new Date(props.endDate).setHours(23, 59, 59, 999)
+  darkMediaQuery.addEventListener('change', onThemeChange);
+  const minStartTime = new Date(props.startDate).setHours(0, 0, 0, 0);
+  const maxEndTime = new Date(props.endDate).setHours(23, 59, 59, 999);
   if (props.startDate > minStartTime) {
-    chartStartDate.value = props.startDate
+    chartStartDate.value = props.startDate;
   } else {
-    chartStartDate.value = minStartTime
+    chartStartDate.value = minStartTime;
   }
   if (props.endDate <= maxEndTime) {
-    chartEndDate.value = props.endDate
+    chartEndDate.value = props.endDate;
   } else {
-    chartEndDate.value = maxEndTime
+    chartEndDate.value = maxEndTime;
   }
-  buildChart()
-})
+  buildChart();
+});
 
 onUnmounted(() => {
-  darkMediaQuery.removeEventListener('change', onThemeChange)
-})
+  darkMediaQuery.removeEventListener('change', onThemeChange);
+});
 
 const svgHeight = computed(() => {
   if (props.type === 'WINDOW_ACTIVITY') {
-    return 135
+    return 135;
   } else {
-    return 100
+    return 100;
   }
-})
+});
 
 watch([() => props.data], () => {
-  rebuildChartWithAnimation()
-})
+  rebuildChartWithAnimation();
+});
 
 function getActiveTaskTotalTimeSpentPerActivityGroupArray() {
   const activeTaskTotalTimeSpentPerActivityGroup: {
-    activityGroup: string
-    totalTime: number
-    timeInPercentage: number
-  }[] = []
-  let totalTimeSpent = 0
+    activityGroup: string;
+    totalTime: number;
+    timeInPercentage: number;
+  }[] = [];
+  let totalTimeSpent = 0;
   props.data.forEach((dataPoint: any) => {
-    const activityGroup = getActivityGroupFromActivityName(dataPoint.activity)
-    const totalTime = dataPoint.end - dataPoint.start
+    const activityGroup = getActivityGroupFromActivityName(dataPoint.activity);
+    const totalTime = dataPoint.end - dataPoint.start;
     const existingActivityGroup = activeTaskTotalTimeSpentPerActivityGroup.find(
       (item) => item.activityGroup === activityGroup
-    )
+    );
     if (existingActivityGroup) {
-      existingActivityGroup.totalTime += totalTime
+      existingActivityGroup.totalTime += totalTime;
     } else {
       activeTaskTotalTimeSpentPerActivityGroup.push({
         activityGroup,
         totalTime,
         timeInPercentage: 0
-      })
+      });
     }
-    totalTimeSpent += totalTime
-  })
-  activeTaskTotalTimeSpentPerActivityGroup.sort((a, b) => b.totalTime - a.totalTime)
+    totalTimeSpent += totalTime;
+  });
+  activeTaskTotalTimeSpentPerActivityGroup.sort((a, b) => b.totalTime - a.totalTime);
   activeTaskTotalTimeSpentPerActivityGroup.forEach((item) => {
-    item.timeInPercentage = (item.totalTime / totalTimeSpent) * 100
-  })
-  return activeTaskTotalTimeSpentPerActivityGroup
+    item.timeInPercentage = (item.totalTime / totalTimeSpent) * 100;
+  });
+  return activeTaskTotalTimeSpentPerActivityGroup;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function shouldShowAppName(detail: TimelineHoverDetail): boolean {
+  if (!detail.appName) {
+    return false;
+  }
+  return detail.appName.trim().toLowerCase() !== detail.title.trim().toLowerCase();
+}
+
+function getDetailInitial(detail: TimelineHoverDetail): string {
+  return (detail.appName || detail.title).trim().charAt(0).toUpperCase() || '?';
+}
+
+function renderTooltipDetailIcon(detail: TimelineHoverDetail): string {
+  if (detail.iconDataUrl) {
+    return `<img src="${escapeHtml(detail.iconDataUrl)}" alt="" style="width: 16px; height: 16px; border-radius: 4px; flex: 0 0 auto;" />`;
+  }
+
+  return `
+    <span style="width: 16px; height: 16px; border-radius: 4px; flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; background: rgba(148, 163, 184, 0.22); color: #64748b; font-size: 10px; font-weight: 700;">
+      ${escapeHtml(getDetailInitial(detail))}
+    </span>
+  `;
+}
+
+function renderTooltipDetail(detail: TimelineHoverDetail): string {
+  const duration = msToReadableFormat(detail.durationMs, false, false);
+  const title = escapeHtml(detail.title);
+  const tooltipTitle = escapeHtml(detail.tooltipTitle || detail.title);
+  const appName = detail.appName ? escapeHtml(detail.appName) : '';
+  const appLabel = shouldShowAppName(detail)
+    ? `<span style="color: #64748b;">${appName}</span>`
+    : '';
+
+  return `
+    <li title="${tooltipTitle}" style="display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 10px; align-items: center;">
+      <span style="min-width: 0; display: inline-flex; align-items: center; gap: 6px;">
+        ${renderTooltipDetailIcon(detail)}
+        <span style="min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+          ${title}${appLabel ? `<span style="color: #94a3b8;"> &middot; </span>${appLabel}` : ''}
+        </span>
+      </span>
+      <span style="color: #64748b; white-space: nowrap;">${duration}</span>
+    </li>
+  `;
+}
+
+function renderTooltipDetails(dataPoint: ChartDataPoint): string {
+  if (!dataPoint.details?.length) {
+    return '';
+  }
+
+  const detailRows = dataPoint.details.map(renderTooltipDetail).join('');
+  const hiddenDetailCount = dataPoint.hiddenDetailCount || 0;
+  const hiddenRow =
+    hiddenDetailCount > 0 ? `<li style="color: #64748b;">+ ${hiddenDetailCount} more</li>` : '';
+
+  return `
+    <ol style="margin: 8px 0 0; padding: 8px 0 0; border-top: 1px solid rgba(148, 163, 184, 0.35); list-style: none; text-align: left;">
+      ${detailRows}
+      ${hiddenRow}
+    </ol>
+  `;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function positionTooltip(event: MouseEvent, barBoundingRect: DOMRect) {
+  const viewportPadding = 8;
+  const tooltipGap = 10;
+  const tooltip = d3.select<HTMLDivElement, unknown>('#tooltip');
+  const tooltipNode = tooltip.node();
+  if (!tooltipNode) {
+    return;
+  }
+
+  const tooltipRect = tooltipNode.getBoundingClientRect();
+  const maxLeft = Math.max(
+    viewportPadding,
+    window.innerWidth - tooltipRect.width - viewportPadding
+  );
+  const left = clamp(event.clientX - tooltipRect.width / 2, viewportPadding, maxLeft);
+
+  const topAboveBar = barBoundingRect.top - tooltipRect.height - tooltipGap;
+  const topBelowBar = barBoundingRect.bottom + tooltipGap;
+  const maxTop = Math.max(
+    viewportPadding,
+    window.innerHeight - tooltipRect.height - viewportPadding
+  );
+  const top =
+    topAboveBar >= viewportPadding ? topAboveBar : clamp(topBelowBar, viewportPadding, maxTop);
+
+  tooltip
+    .style('left', `${left + window.scrollX}px`)
+    .style('top', `${top + window.scrollY}px`)
+    .style('transform', 'none');
 }
 
 function buildChart() {
-  const margin = { top: 20, right: 0, bottom: 30, left: 0 }
-  const width = svgWidth - margin.left - margin.right
-  const height = svgHeight.value - margin.top - margin.bottom
+  const margin = { top: 20, right: 0, bottom: 30, left: 0 };
+  const width = svgWidth - margin.left - margin.right;
+  const height = svgHeight.value - margin.top - margin.bottom;
 
-  const barHeight = 35
-  const barYOffset = -10
+  const barHeight = 35;
+  const barYOffset = -10;
 
   const svg = d3
     .select(chart.value!)
@@ -134,7 +247,7 @@ function buildChart() {
     .attr('width', width + margin.left + margin.right)
     .attr('height', height + margin.top + margin.bottom)
     .append('g')
-    .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')')
+    .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
   svg
     .append('rect')
@@ -145,11 +258,11 @@ function buildChart() {
     .attr('height', barHeight)
     .attr('fill', isDark.value ? (Color as any)['neutral-800'] : '#e5e7eb')
     .style('opacity', 1)
-    .attr('rx', 8)
+    .attr('rx', 8);
 
-  const x = d3.scaleTime().domain([chartStartDate.value!, chartEndDate.value!]).range([0, width])
+  const x = d3.scaleTime().domain([chartStartDate.value!, chartEndDate.value!]).range([0, width]);
 
-  const timeFormat = d3.timeFormat('%H:%M')
+  const timeFormat = d3.timeFormat('%H:%M');
 
   svg
     .selectAll('.bar')
@@ -157,7 +270,7 @@ function buildChart() {
     .enter()
     .append('rect')
     .attr('class', (d: any) => {
-      return `bar bar-${getActivityGroupFromActivityName(d.activity)}`
+      return `bar bar-${getActivityGroupFromActivityName(d.activity)}`;
     })
     .attr('x', (d: any) => x(d.start))
     .attr('width', (d: any) => x(d.end) - x(d.start))
@@ -165,98 +278,100 @@ function buildChart() {
     .attr('height', barHeight)
     .style('fill', (d: any) => {
       if (d.type === DataPointType.USER_COMPUTER_ACTIVITY) {
-        return (Color as any)['neutral-400']
+        return (Color as any)['neutral-400'];
       }
-      return getBarColorFromDataPoint(d.color)
+      return getBarColorFromDataPoint(d.color);
     })
     .style('opacity', 1)
     .on('mouseover', function () {
-      d3.select('#tooltip').style('opacity', null)
+      d3.select('#tooltip').style('opacity', null);
     })
     .on('mouseout', function () {
-      d3.select('#tooltip').style('opacity', '0')
+      d3.select('#tooltip').style('opacity', '0');
     })
-    .on('mousemove', function (this: SVGRectElement, _event: any, d: unknown) {
-      const dataPoint = d as ChartDataPoint
-      const durationInMinutes = msToReadableFormat(dataPoint.end.getTime() - dataPoint.start.getTime(), false, false)
+    .on('mousemove', function (this: SVGRectElement, event: MouseEvent, d: unknown) {
+      const dataPoint = d as ChartDataPoint;
+      const durationInMinutes = msToReadableFormat(
+        dataPoint.end.getTime() - dataPoint.start.getTime(),
+        false,
+        false
+      );
 
-      const barBoundingRect = this.getBoundingClientRect()
-      const xPosition = barBoundingRect.x + barBoundingRect.width / 2
-      const yPosition = barBoundingRect.y - barBoundingRect.height + 10
+      const barBoundingRect = this.getBoundingClientRect();
 
-      const tooltipContent = `<div class="text-${dataPoint.color}">${ACTIVITY_LABELS[getActivityGroupFromActivityName(dataPoint.activity)]}</div> ${timeFormat(dataPoint.start)} - ${timeFormat(dataPoint.end)} (${durationInMinutes})`
+      const tooltipContent = `
+        <div class="text-${dataPoint.color}" style="font-weight: 600; text-align: center;">${ACTIVITY_LABELS[getActivityGroupFromActivityName(dataPoint.activity)]}</div>
+        <div style="text-align: center;">${timeFormat(dataPoint.start)} - ${timeFormat(dataPoint.end)} (${durationInMinutes})</div>
+        ${renderTooltipDetails(dataPoint)}
+      `;
 
-      d3.select('#tooltip')
-        .style('left', xPosition + 'px')
-        .style('top', yPosition + 'px')
-        .style('opacity', '1')
-        .style('transform', `translate(-50%, -${barBoundingRect.height}px)`)
-        .select('#content')
-        .html(tooltipContent)
-    })
+      const tooltip = d3.select('#tooltip');
+      tooltip.style('opacity', '1').select('#content').html(tooltipContent);
+      positionTooltip(event, barBoundingRect);
+    });
 
   // Add legend for window activity
   if (props.type === 'WINDOW_ACTIVITY') {
-    drawLegend(getLegendDataForWindowActivity(), true)
+    drawLegend(getLegendDataForWindowActivity(), true);
   }
 
-  const axisColor = isDark.value ? '#a3a3a3' : '#374151'
+  const axisColor = isDark.value ? '#a3a3a3' : '#374151';
   svg
     .append('g')
     .attr('class', 'x axis')
     .attr('transform', `translate(0, ${barYOffset + barHeight})`)
     .call(d3.axisBottom(x).tickFormat(timeFormat as any))
     .selectAll('text')
-    .style('fill', axisColor)
+    .style('fill', axisColor);
 
-  svg.selectAll('.x.axis path, .x.axis line').style('stroke', axisColor)
+  svg.selectAll('.x.axis path, .x.axis line').style('stroke', axisColor);
 }
 
 interface LegendDataPoint {
-  text: string
-  color: string
-  key: string
+  text: string;
+  color: string;
+  key: string;
 }
 
 function getLegendDataForWindowActivity(): LegendDataPoint[] {
-  const legendData: LegendDataPoint[] = []
+  const legendData: LegendDataPoint[] = [];
   const activeTaskTotalTimeSpentPerActivityGroup =
-    getActiveTaskTotalTimeSpentPerActivityGroupArray()
+    getActiveTaskTotalTimeSpentPerActivityGroupArray();
   activeTaskTotalTimeSpentPerActivityGroup.forEach((item) => {
     legendData.push({
       text: `${ACTIVITY_LABELS[item.activityGroup] || 'Other'} (${msToReadableFormat(item.totalTime, false, false)})`,
       color: (Color as any)[TW_CLASS_ACTIVITY_MAPPINGS[item.activityGroup]],
       key: item.activityGroup
-    })
-  })
-  return legendData
+    });
+  });
+  return legendData;
 }
 
 function drawLegend(legendData: LegendDataPoint[], enableClickableLegend = false) {
   // Remove existing legend elements
-  d3.select(chart.value!).select('.legend').remove()
-  d3.select(chart.value!).append('g').attr('class', 'legend')
+  d3.select(chart.value!).select('.legend').remove();
+  d3.select(chart.value!).append('g').attr('class', 'legend');
 
-  const legendStartPositionY = 85
-  const legendStartPositionX = 35
-  const dotRadius = 5
-  const lineHeight = 22
+  const legendStartPositionY = 85;
+  const legendStartPositionX = 35;
+  const dotRadius = 5;
+  const lineHeight = 22;
 
-  let totalWidth = legendStartPositionX
-  const legendPositions: number[] = []
-  const startNewLinesAtItemIndex: number[] = []
-  let currentLegendItemLine = 0
-  const legendLabels = d3.select(chart.value!).select('.legend').selectAll('.legend-label')
+  let totalWidth = legendStartPositionX;
+  const legendPositions: number[] = [];
+  const startNewLinesAtItemIndex: number[] = [];
+  let currentLegendItemLine = 0;
+  const legendLabels = d3.select(chart.value!).select('.legend').selectAll('.legend-label');
   legendLabels
     .data(legendData)
     .enter()
     .append('text')
     .attr('class', (d: LegendDataPoint) => `legend-label legend-label-${d.key}`)
     .style('fill', function (d: LegendDataPoint) {
-      return d.color
+      return d.color;
     })
     .text(function (d: LegendDataPoint) {
-      return d.text
+      return d.text;
     })
     .style('user-select', 'none')
     .attr('font-size', '12px')
@@ -264,24 +379,24 @@ function drawLegend(legendData: LegendDataPoint[], enableClickableLegend = false
     .style('alignment-baseline', 'middle')
     .style('opacity', 1)
     .attr('x', function (this: SVGTextElement, _d: LegendDataPoint, i: number) {
-      const current = d3.select(this)
-      const currentNodeWidth = current.node()!.getBBox().width
-      let previousWidth = totalWidth
+      const current = d3.select(this);
+      const currentNodeWidth = current.node()!.getBBox().width;
+      let previousWidth = totalWidth;
       if (previousWidth + currentNodeWidth + 35 > svgWidth) {
-        startNewLinesAtItemIndex.push(i)
-        totalWidth = legendStartPositionX
-        previousWidth = legendStartPositionX
+        startNewLinesAtItemIndex.push(i);
+        totalWidth = legendStartPositionX;
+        previousWidth = legendStartPositionX;
       }
-      legendPositions.push(totalWidth)
-      totalWidth += currentNodeWidth + 35
-      return previousWidth
+      legendPositions.push(totalWidth);
+      totalWidth += currentNodeWidth + 35;
+      return previousWidth;
     })
     .attr('y', function (_d: LegendDataPoint, i: number) {
       if (startNewLinesAtItemIndex.includes(i)) {
-        currentLegendItemLine++
+        currentLegendItemLine++;
       }
-      return legendStartPositionY + lineHeight * currentLegendItemLine + 1
-    })
+      return legendStartPositionY + lineHeight * currentLegendItemLine + 1;
+    });
 
   if (enableClickableLegend) {
     d3.select(chart.value!)
@@ -289,28 +404,26 @@ function drawLegend(legendData: LegendDataPoint[], enableClickableLegend = false
       .selectAll('.legend-label')
       .attr('cursor', 'pointer')
       .on('click', function (_e: any, d: any) {
-        d3.select(chart.value!).selectAll(`.legend-label`).style('opacity', null)
-        d3.select(chart.value!).selectAll(`.legend-dot`).style('opacity', null)
-        d3.select(chart.value!).selectAll(`.bar`).style('opacity', null)
+        d3.select(chart.value!).selectAll(`.legend-label`).style('opacity', null);
+        d3.select(chart.value!).selectAll(`.legend-dot`).style('opacity', null);
+        d3.select(chart.value!).selectAll(`.bar`).style('opacity', null);
         if (chartSelectedLegendItem.value === d.key) {
-          chartSelectedLegendItem.value = null
-          return
+          chartSelectedLegendItem.value = null;
+          return;
         } else {
-          chartSelectedLegendItem.value = d.key
+          chartSelectedLegendItem.value = d.key;
           d3.select(chart.value!)
             .selectAll(`.legend-label:not(.legend-label-${d.key})`)
-            .style('opacity', 0.3)
+            .style('opacity', 0.3);
           d3.select(chart.value!)
             .selectAll(`.legend-dot:not(.legend-dot-${d.key})`)
-            .style('opacity', 0.3)
-          d3.select(chart.value!)
-            .selectAll(`.bar:not(.bar-${d.key})`)
-            .style('opacity', 0.15)
+            .style('opacity', 0.3);
+          d3.select(chart.value!).selectAll(`.bar:not(.bar-${d.key})`).style('opacity', 0.15);
         }
-      })
+      });
   }
 
-  currentLegendItemLine = 0
+  currentLegendItemLine = 0;
   d3.select(chart.value!)
     .select('.legend')
     .selectAll('.legend-dot')
@@ -319,42 +432,42 @@ function drawLegend(legendData: LegendDataPoint[], enableClickableLegend = false
     .append('circle')
     .attr('class', (d: LegendDataPoint) => `legend-dot legend-dot-${d.key}`)
     .attr('cx', function (_d: LegendDataPoint, i: number) {
-      return legendPositions[i] - 10
+      return legendPositions[i] - 10;
     })
     .attr('cy', function (_d: LegendDataPoint, i: number) {
       if (startNewLinesAtItemIndex.includes(i)) {
-        currentLegendItemLine++
+        currentLegendItemLine++;
       }
-      return legendStartPositionY + lineHeight * currentLegendItemLine
+      return legendStartPositionY + lineHeight * currentLegendItemLine;
     })
     .attr('r', dotRadius)
     .style('fill', function (d: LegendDataPoint) {
-      return d.color
+      return d.color;
     })
-    .style('opacity', 1)
+    .style('opacity', 1);
 }
 
 function rebuildChartWithAnimation() {
-  chartSelectedLegendItem.value = null
-  const margin = { top: 20, right: 20, bottom: 40, left: 20 }
-  const width = svgWidth - margin.left - margin.right
-  const svg = d3.select(chart.value!).select('svg')
-  const x = d3.scaleTime().domain([chartStartDate.value!, chartEndDate.value!]).range([0, width])
+  chartSelectedLegendItem.value = null;
+  const margin = { top: 20, right: 20, bottom: 40, left: 20 };
+  const width = svgWidth - margin.left - margin.right;
+  const svg = d3.select(chart.value!).select('svg');
+  const x = d3.scaleTime().domain([chartStartDate.value!, chartEndDate.value!]).range([0, width]);
 
-  const bars = svg.selectAll('.bar').data(props.data)
+  const bars = svg.selectAll('.bar').data(props.data);
 
   bars
     .transition()
     .duration(300)
     .attr('x', (d: any) => x(d.start))
     .attr('width', (d: any) => x(d.end) - x(d.start))
-    .style('opacity', 1)
+    .style('opacity', 1);
 
-  bars.exit().transition().duration(300).attr('width', 0).remove()
+  bars.exit().transition().duration(300).attr('width', 0).remove();
 
   // Update legend
   if (props.type === 'WINDOW_ACTIVITY') {
-    drawLegend(getLegendDataForWindowActivity(), true)
+    drawLegend(getLegendDataForWindowActivity(), true);
   }
 }
 </script>
@@ -362,8 +475,9 @@ function rebuildChartWithAnimation() {
 <style scoped>
 #tooltip {
   position: absolute;
-  text-align: center;
+  text-align: left;
   width: auto;
+  max-width: 360px;
   height: auto;
   padding: 5px 10px;
   border-radius: 10px;

--- a/src/electron/src/utils/retrospection/types.ts
+++ b/src/electron/src/utils/retrospection/types.ts
@@ -10,6 +10,8 @@ export interface ChartDataPoint {
   color: string;
   type: DataPointType;
   activity: Activity;
+  details?: TimelineHoverDetail[];
+  hiddenDetailCount?: number;
 }
 
 export interface PieChartDataPoint {
@@ -47,6 +49,8 @@ export interface TimeActive {
   from: Date;
   to: Date;
   duration: number;
+  details?: TimelineHoverDetail[];
+  hiddenDetailCount?: number;
 }
 
 export interface ActivitySessions {
@@ -55,6 +59,15 @@ export interface ActivitySessions {
   sessions: TimeActive[];
   activity?: string;
   tooltipTitle?: string;
+}
+
+export interface TimelineHoverDetail {
+  title: string;
+  appName?: string | null;
+  durationMs: number;
+  tooltipTitle?: string;
+  activity?: string;
+  iconDataUrl?: string;
 }
 
 export enum Color {

--- a/src/electron/src/utils/retrospection/utils.ts
+++ b/src/electron/src/utils/retrospection/utils.ts
@@ -1,28 +1,28 @@
-import { Color, Activity } from './types'
+import { Color, Activity } from './types';
 
 export function msToReadableFormat(
   durationInMs: number,
   flashColon: boolean = false,
   showSeconds: boolean = false
 ): string {
-  const flash: ':' | ' ' = flashColon ? (Math.floor(Date.now() / 1000) % 2 === 0 ? ':' : ' ') : ':'
+  const flash: ':' | ' ' = flashColon ? (Math.floor(Date.now() / 1000) % 2 === 0 ? ':' : ' ') : ':';
 
-  const hours = Math.floor(durationInMs / (1000 * 60 * 60))
-  const minutes = Math.floor((durationInMs % (1000 * 60 * 60)) / (1000 * 60))
-  const seconds = Math.floor((durationInMs % (1000 * 60)) / 1000)
+  const hours = Math.floor(durationInMs / (1000 * 60 * 60));
+  const minutes = Math.floor((durationInMs % (1000 * 60 * 60)) / (1000 * 60));
+  const seconds = Math.floor((durationInMs % (1000 * 60)) / 1000);
 
-  const formattedHours = String(hours).padStart(2, '0')
-  const formattedMinutes = String(minutes).padStart(2, '0')
-  const formattedSeconds = String(seconds).padStart(2, '0')
+  const formattedHours = String(hours).padStart(2, '0');
+  const formattedMinutes = String(minutes).padStart(2, '0');
+  const formattedSeconds = String(seconds).padStart(2, '0');
 
-  let formatWithoutSeconds = `${formattedHours}${flash}${formattedMinutes}`
+  let formatWithoutSeconds = `${formattedHours}${flash}${formattedMinutes}`;
   if (formatWithoutSeconds === '00:00') {
-    formatWithoutSeconds = '< 00:01'
+    formatWithoutSeconds = '< 00:01';
   }
 
   return showSeconds
     ? `${formattedHours}${flash}${formattedMinutes}${flash}${formattedSeconds}`
-    : `${formatWithoutSeconds}`
+    : `${formatWithoutSeconds}`;
 }
 
 const ACTIVITY_GROUPS: Record<string, Activity[]> = {
@@ -40,7 +40,7 @@ const ACTIVITY_GROUPS: Record<string, Activity[]> = {
   FileManagement: [Activity.FileManagement],
   Other: [Activity.Unknown, Activity.Other, Activity.OtherRdp],
   Idle: [Activity.Idle]
-}
+};
 
 export const TW_CLASS_ACTIVITY_MAPPINGS: Record<string, string> = {
   Development: 'sky-400',
@@ -56,8 +56,8 @@ export const TW_CLASS_ACTIVITY_MAPPINGS: Record<string, string> = {
   SocialMedia: 'red-600',
   FileManagement: 'teal-600',
   Other: 'neutral-400',
-  Idle: 'neutral-400',
-}
+  Idle: 'neutral-400'
+};
 
 export const ACTIVITY_LABELS: Record<string, string> = {
   Development: 'Coding',
@@ -74,23 +74,36 @@ export const ACTIVITY_LABELS: Record<string, string> = {
   FileManagement: 'File Management',
   Other: 'Other',
   Idle: 'Idle'
-}
+};
 
 export function getBarColorFromDataPoint(tailwindColorClass: string): string {
-  return (Color as any)[tailwindColorClass]
+  return (Color as any)[tailwindColorClass];
 }
 
 export function getActivityGroupFromActivityName(activityName: string): string {
   const activityGroup: string | undefined = Object.keys(ACTIVITY_GROUPS).find((group) =>
     ACTIVITY_GROUPS[group].includes(activityName as Activity)
-  )
-  return activityGroup || 'Other'
+  );
+  return activityGroup || 'Other';
 }
 
 export function getTailwindClassFromActivity(activityName: string, isGroup = false): string {
   if (isGroup) {
-    return TW_CLASS_ACTIVITY_MAPPINGS[activityName]
+    return TW_CLASS_ACTIVITY_MAPPINGS[activityName];
   }
-  const activityGroup = getActivityGroupFromActivityName(activityName)
-  return TW_CLASS_ACTIVITY_MAPPINGS[activityGroup]
+  const activityGroup = getActivityGroupFromActivityName(activityName);
+  return TW_CLASS_ACTIVITY_MAPPINGS[activityGroup];
+}
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
 }

--- a/src/electron/src/views/RetrospectionView.vue
+++ b/src/electron/src/views/RetrospectionView.vue
@@ -15,6 +15,7 @@ import {
   getTailwindClassFromActivity
 } from '../utils/retrospection/utils';
 import StackedBarChart from '../components/StackedBarChart.vue';
+import studyConfig from '../../shared/study.config';
 
 const typedIpcRenderer = window.ipcRenderer;
 const isLoading = ref(false);
@@ -28,6 +29,7 @@ const topWindowTitles = ref<ActivitySessions[]>([]);
 const ACTIVITY_BREAKDOWN_COVERAGE = 0.9;
 const ACTIVITY_BREAKDOWN_MAX_ITEMS = 6;
 const EXCLUDED_ACTIVITY_BREAKDOWN_GROUPS = new Set(['Other', 'Unknown']);
+const isWindowActivityTrackerEnabled = studyConfig.trackers.windowActivityTracker.enabled;
 
 interface ActivityBreakdownDataPoint extends PieChartDataPoint {
   percentage: number;
@@ -177,7 +179,9 @@ function windowActivitiesToChartData() {
         activity: activitySession.type as Activity,
         start: session.from,
         end: session.to,
-        color: getTailwindClassFromActivity(activitySession.type)
+        color: getTailwindClassFromActivity(activitySession.type),
+        details: session.details,
+        hiddenDetailCount: session.hiddenDetailCount
       });
     });
   });
@@ -374,12 +378,25 @@ function getDayLabel(date: Date): string {
           :disabled="isToday"
           class="h-8 rounded border border-gray-300 bg-white px-3 text-sm text-gray-800 disabled:opacity-40 dark:border-neutral-600 dark:bg-neutral-700 dark:text-slate-200"
           @click="navigateToToday"
-        >Today</button>
+        >
+          Today
+        </button>
         <button
           class="h-8 rounded border border-gray-300 bg-white px-2 text-gray-800 dark:border-neutral-600 dark:bg-neutral-700 dark:text-slate-200"
           @click="navigateToPreviousDay"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><polyline points="15 18 9 12 15 6"/></svg>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="h-4 w-4"
+          >
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
         </button>
         <input
           type="date"
@@ -394,14 +411,33 @@ function getDayLabel(date: Date): string {
           class="h-8 rounded border border-gray-300 bg-white px-2 text-gray-800 disabled:opacity-40 dark:border-neutral-600 dark:bg-neutral-700 dark:text-slate-200"
           @click="navigateToNextDay"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><polyline points="9 18 15 12 9 6"/></svg>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="h-4 w-4"
+          >
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
         </button>
       </div>
       <div class="text-center text-gray-800 dark:text-gray-200">
-        <h1 class="mb-8 text-2xl font-bold">No data for this day.</h1>
-        <span class="text-gray-600 dark:text-gray-400"
-          >There is no data recorded for this date. Please select a different day.</span
-        >
+        <template v-if="isWindowActivityTrackerEnabled">
+          <h1 class="mb-8 text-2xl font-bold">No data for this day.</h1>
+          <span class="text-gray-600 dark:text-gray-400"
+            >There is no data recorded for this date. Please select a different day.</span
+          >
+        </template>
+        <template v-else>
+          <h1 class="mb-8 text-2xl font-bold">Retrospection data is not available.</h1>
+          <span class="text-gray-600 dark:text-gray-400"
+            >Window activity tracking is disabled for this study.</span
+          >
+        </template>
       </div>
     </div>
   </template>
@@ -415,12 +451,25 @@ function getDayLabel(date: Date): string {
           :disabled="isToday"
           class="h-8 rounded border border-gray-300 bg-white px-3 text-sm text-gray-800 disabled:opacity-40 dark:border-neutral-600 dark:bg-neutral-700 dark:text-slate-200"
           @click="navigateToToday"
-        >Today</button>
+        >
+          Today
+        </button>
         <button
           class="h-8 rounded border border-gray-300 bg-white px-2 text-gray-800 dark:border-neutral-600 dark:bg-neutral-700 dark:text-slate-200"
           @click="navigateToPreviousDay"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><polyline points="15 18 9 12 15 6"/></svg>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="h-4 w-4"
+          >
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
         </button>
         <input
           type="date"
@@ -435,13 +484,24 @@ function getDayLabel(date: Date): string {
           class="h-8 rounded border border-gray-300 bg-white px-2 text-gray-800 disabled:opacity-40 dark:border-neutral-600 dark:bg-neutral-700 dark:text-slate-200"
           @click="navigateToNextDay"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><polyline points="9 18 15 12 9 6"/></svg>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="h-4 w-4"
+          >
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
         </button>
       </div>
 
       <div>
         <h1 class="primary-blue mb-3 text-2xl font-bold">
-          {{ getDayLabel(selectedDay) }}  in Review
+          {{ getDayLabel(selectedDay) }} in Review
         </h1>
         <div class="subline mb-8 text-gray-600 dark:text-gray-400">
           Take a moment to reflect on your workday.


### PR DESCRIPTION
# Refine Retrospection Timeline Hover Details (Closes #510)

## Description

Improves the `Activities over time` hover overlay in Retrospection. The tooltip now gives more context for each activity segment by showing the most relevant window titles, app names, durations, and app icons.

### Changes Made

- Added timeline hover detail aggregation for activity sessions
- Shows the top window/app details for each hovered activity segment
- Cleans and trims noisy window titles before display
- Removes redundant app/title suffixes where possible
- Adds native app icons from captured process paths
- Falls back to compact initial badges when an app icon is unavailable
- Keeps tooltip content bounded to the top items with a `+ N more` row
- Repositions the tooltip above the timeline segment
- Clamps tooltip placement so it does not overflow outside the viewport
- Adds a clearer Retrospection empty state when window activity tracking is disabled

## Screenshots

| Timeline hover with app/window details | Timeline hover with multiple details |
|:-:|:-:|
| <img width="400" alt="Retrospection timeline hover with app and window details" src="https://github.com/user-attachments/assets/e15fc810-5353-48c5-b054-7181806c3b33" /> | <img width="400" alt="Retrospection timeline hover showing multiple window details" src="https://github.com/user-attachments/assets/43a001af-2c91-4eeb-86fe-c91478b76bd9" /> |

Closes #510