### PR TITLE
[#513] Refine active hours in retrospection

### DIFF
--- a/src/electron/electron/ipc/IpcHandler.ts
+++ b/src/electron/electron/ipc/IpcHandler.ts
@@ -26,6 +26,7 @@ import { WorkScheduleService } from 'electron/main/services/WorkScheduleService'
 import { WorkHoursDto } from 'shared/dto/WorkHoursDto';
 import {
   getActivitySessions,
+  getActiveHoursInsight,
   getAppUsageSessions,
   getLongestTimeActiveInsight,
   getTopWebsiteSessions,
@@ -110,6 +111,7 @@ export class IpcHandler {
       startAllTrackers: this.startAllTrackers,
       triggerPermissionCheckAccessibility: this.triggerPermissionCheckAccessibility,
       triggerPermissionCheckScreenRecording: this.triggerPermissionCheckScreenRecording,
+      retrospectionGetActiveHours: this.retrospectionGetActiveHours,
       retrospectionGetActivities: this.retrospectionGetActivities,
       retrospectionLoadLongestTimeActive: this.retrospectionLoadLongestTimeActive,
       retrospectionGetTopThreeMostActiveApps: this.retrospectionGetTopThreeMostActiveApps,
@@ -333,6 +335,10 @@ export class IpcHandler {
 
   private async retrospectionGetActivities(date: Date): Promise<ActivitySessions[]> {
     return await getActivitySessions(new Date(date));
+  }
+
+  private async retrospectionGetActiveHours(date: Date) {
+    return await getActiveHoursInsight(new Date(date));
   }
 
   private async retrospectionLoadLongestTimeActive(date: Date): Promise<TimeActive | undefined> {

--- a/src/electron/electron/main/__tests__/RetrospectionService.test.ts
+++ b/src/electron/electron/main/__tests__/RetrospectionService.test.ts
@@ -11,6 +11,8 @@ jest.unstable_mockModule('electron', () => ({
 const {
   cleanWindowTitle,
   getReadableUrlTitle,
+  getRetrospectionWorkdayRange,
+  getWorkdayMinuteIndex,
   isBrowserProcessName,
   removeGenericBrowserTabCountFragments,
   stripPathFragment
@@ -250,4 +252,26 @@ const cases: [string, string | boolean | null, string | boolean | null][] = [
 
 test.each(cases)('.cleanWindowTitle helpers: %s', (_name, actual, expected) => {
   expect(actual).toBe(expected);
+});
+
+test('retrospection workday uses a 04:00 local cutoff', () => {
+  const { start, end } = getRetrospectionWorkdayRange(new Date(2026, 5, 29, 12, 0));
+
+  expect(start.getFullYear()).toBe(2026);
+  expect(start.getMonth()).toBe(5);
+  expect(start.getDate()).toBe(29);
+  expect(start.getHours()).toBe(4);
+  expect(start.getMinutes()).toBe(0);
+  expect(end.getFullYear()).toBe(2026);
+  expect(end.getMonth()).toBe(5);
+  expect(end.getDate()).toBe(30);
+  expect(end.getHours()).toBe(4);
+  expect(end.getMinutes()).toBe(0);
+});
+
+test('workday minute index carries late-night activity into the selected workday', () => {
+  const { start } = getRetrospectionWorkdayRange(new Date(2026, 5, 29, 12, 0));
+
+  expect(getWorkdayMinuteIndex(new Date(2026, 5, 29, 4, 0), start)).toBe(0);
+  expect(getWorkdayMinuteIndex(new Date(2026, 5, 30, 2, 30), start)).toBe(22 * 60 + 30);
 });

--- a/src/electron/electron/main/services/RetrospectionService.ts
+++ b/src/electron/electron/main/services/RetrospectionService.ts
@@ -1,7 +1,7 @@
 import { UserInputEntity } from '../entities/UserInputEntity';
 import { WindowActivityEntity } from '../entities/WindowActivityEntity';
 import { getMainLogger } from '../../config/Logger';
-import { Activity } from '../../../src/utils/retrospection/types';
+import { Activity, type ActiveHoursInsight } from '../../../src/utils/retrospection/types';
 
 const LOG = getMainLogger('RetrospectionService');
 
@@ -20,6 +20,8 @@ export interface ActivitySessions {
 }
 
 type WindowActivitySessionKeySelector = (activity: WindowActivityEntity) => string | null;
+
+const WORKDAY_CUTOFF_HOUR = 4;
 
 // Mirrored from PA.WindowsActivityTracker/typescript/src/mappings/browsers.ts.
 // Used here to recognize browser processes without importing tracker source into the main bundle.
@@ -121,41 +123,67 @@ export function isBrowserProcessName(processName: string | null): boolean {
 }
 
 /**
- * converts a date object to a minute of the day (0-1439)
- * @param date - date object
- * @returns the minute of the day (0-1439)
+ * Formats a date as a SQLite-local datetime string.
+ *
+ * Retrospection queries compare against `datetime(..., 'localtime')`, so parameters must be local
+ * wall-clock timestamps instead of UTC ISO strings.
  */
-function getMinuteOfDay(date: Date): number {
-  return date.getHours() * 60 + date.getMinutes();
+function formatSqliteLocalDateTime(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  const hours = `${date.getHours()}`.padStart(2, '0');
+  const minutes = `${date.getMinutes()}`.padStart(2, '0');
+  const seconds = `${date.getSeconds()}`.padStart(2, '0');
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 }
 
 /**
- * constructs a date object from a minute of the day (0-1439)
- * @param minuteOfDay - minute of the day (0-1439)
- * @returns a date object
+ * Returns the retrospection workday range for the selected calendar day.
+ *
+ * A workday starts at 04:00 local time and ends at 04:00 the next local day, so late-night work
+ * before 04:00 is attributed to the previous workday.
  */
-function getDateFromMinuteOfDay(minuteOfDay: number, baseDate?: Date): Date {
-  const d = baseDate ? new Date(baseDate) : new Date();
-  d.setHours(Math.floor(minuteOfDay / 60), minuteOfDay % 60, 0, 0);
-  return d;
+export function getRetrospectionWorkdayRange(date: Date | string): { start: Date; end: Date } {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  const start = new Date(d.getFullYear(), d.getMonth(), d.getDate(), WORKDAY_CUTOFF_HOUR, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return { start, end };
 }
 
 /**
- * finds and returns all minutes of the day (0-1439) where user input was detected
+ * Converts a timestamp to a minute offset in the 04:00-to-04:00 workday.
+ */
+export function getWorkdayMinuteIndex(date: Date, workdayStart: Date): number {
+  return Math.floor((date.getTime() - workdayStart.getTime()) / 60000);
+}
+
+/**
+ * Constructs a date object from a minute offset in the 04:00-to-04:00 workday.
+ */
+function getDateFromWorkdayMinuteIndex(minuteIndex: number, workdayStart: Date): Date {
+  return new Date(workdayStart.getTime() + minuteIndex * 60000);
+}
+
+/**
+ * finds and returns all minutes of the workday (0-1439) where user input was detected
  * @param date - date to check
- * @returns a Set of active minutes for the given day; minute encoded from 0 to 1439
+ * @returns a Set of active minutes for the given workday; minute encoded from 0 to 1439
  */
 async function getActiveMinutesSet(date: Date | string): Promise<Set<number>> {
-  const d = typeof date === 'string' ? new Date(date) : date;
-  const daystr = d.toISOString().split('T')[0]; // e.g 2025-02-28
-  // get all user input entries for the day in local timezone
+  const workdayRange = getRetrospectionWorkdayRange(date);
+  const workdayStart = formatSqliteLocalDateTime(workdayRange.start);
+  const workdayEnd = formatSqliteLocalDateTime(workdayRange.end);
+  // get all user input entries for the 04:00-to-04:00 workday in local timezone
   const userInputToday = await UserInputEntity.createQueryBuilder('userInput')
     .select([
       'userInput.*',
       // Convert UTC timestamp to local time using strftime
       "datetime(userInput.tsStart, 'localtime') as tsStart"
     ])
-    .where("date(userInput.tsStart, 'localtime') = :daystr", { daystr })
+    .where("datetime(userInput.tsStart, 'localtime') >= :workdayStart", { workdayStart })
+    .andWhere("datetime(userInput.tsStart, 'localtime') < :workdayEnd", { workdayEnd })
     .orderBy('userInput.tsStart', 'ASC')
     .getRawMany();
 
@@ -163,7 +191,10 @@ async function getActiveMinutesSet(date: Date | string): Promise<Set<number>> {
   const activeMinutesSet: Set<number> = new Set();
   userInputToday.forEach((el) => {
     if (el.clickTotal > 0 || el.keysTotal > 0 || el.scrollDelta > 0 || el.movedDistance > 0) {
-      activeMinutesSet.add(getMinuteOfDay(new Date(el.tsStart)));
+      const minuteIndex = getWorkdayMinuteIndex(new Date(el.tsStart), workdayRange.start);
+      if (minuteIndex >= 0 && minuteIndex < 24 * 60) {
+        activeMinutesSet.add(minuteIndex);
+      }
     }
   });
 
@@ -175,12 +206,14 @@ async function getActiveMinutesSet(date: Date | string): Promise<Set<number>> {
  * @returns all window activities for the given day
  */
 export async function getWindowActivities(date: Date | string): Promise<WindowActivityEntity[]> {
-  const d = typeof date === 'string' ? new Date(date) : date;
-  const daystr = d.toISOString().split('T')[0];
+  const workdayRange = getRetrospectionWorkdayRange(date);
+  const workdayStart = formatSqliteLocalDateTime(workdayRange.start);
+  const workdayEnd = formatSqliteLocalDateTime(workdayRange.end);
 
   const res = await WindowActivityEntity.createQueryBuilder('windowActivity')
     .select(['windowActivity.*', "datetime(windowActivity.ts, 'localtime') as ts"])
-    .where("date(windowActivity.ts, 'localtime') = :daystr", { daystr })
+    .where("datetime(windowActivity.ts, 'localtime') >= :workdayStart", { workdayStart })
+    .andWhere("datetime(windowActivity.ts, 'localtime') < :workdayEnd", { workdayEnd })
     .orderBy('windowActivity.ts', 'ASC')
     .getRawMany();
 
@@ -234,14 +267,14 @@ function addSessionWithActiveMinuteSplits(
   to: Date,
   activity: string,
   activeMinutesSet: Set<number>,
-  date: Date
+  workdayStart: Date
 ) {
   if (!sessionKey || to.getTime() <= from.getTime()) {
     return;
   }
 
-  const startMinute = getMinuteOfDay(from);
-  const endMinute = getMinuteOfDay(to);
+  const startMinute = getWorkdayMinuteIndex(from, workdayStart);
+  const endMinute = getWorkdayMinuteIndex(to, workdayStart);
 
   let sessionStart = from;
   if (startMinute + 1 < endMinute) {
@@ -250,13 +283,13 @@ function addSessionWithActiveMinuteSplits(
     for (let m = startMinute; m < endMinute; m++) {
       if (!activeMinutesSet.has(m) && inSession) {
         inSession = false;
-        let sessionEnd = getDateFromMinuteOfDay(m, date);
+        let sessionEnd = getDateFromWorkdayMinuteIndex(m, workdayStart);
         sessionEnd = sessionEnd.getTime() > to.getTime() ? to : sessionEnd;
         addEntry(sessionKey, sessionStart, sessionEnd, activity);
       } else if (!activeMinutesSet.has(m) && !inSession) {
-        sessionStart = getDateFromMinuteOfDay(m, date);
+        sessionStart = getDateFromWorkdayMinuteIndex(m, workdayStart);
       } else if (activeMinutesSet.has(m) && !inSession) {
-        sessionStart = getDateFromMinuteOfDay(m, date);
+        sessionStart = getDateFromWorkdayMinuteIndex(m, workdayStart);
         inSession = true;
       } else if (activeMinutesSet.has(m) && inSession) {
         // session is continuously active
@@ -298,6 +331,7 @@ async function getWindowActivitySessionsByKey(
 ): Promise<ActivitySessions[]> {
   const windowActivityToday = await getWindowActivities(date);
   const activeMinutesSet = await getActiveMinutesSet(date);
+  const workdayStart = getRetrospectionWorkdayRange(date).start;
   // encodes session per processName (=app)
   const sessionsMap: Map<string, ActivitySessions> = new Map();
   // helper function to add an entry to the sessionsMap
@@ -306,7 +340,7 @@ async function getWindowActivitySessionsByKey(
   // reconstruct the day so far by iterating over the window activities
   let lastWindowActivity: WindowActivityEntity | undefined = undefined;
   for (const activity of windowActivityToday) {
-    if (!activeMinutesSet.has(getMinuteOfDay(new Date(activity.ts)))) {
+    if (!activeMinutesSet.has(getWorkdayMinuteIndex(new Date(activity.ts), workdayStart))) {
       // found window activity during a minute without any logged user input
       // skip for safety
       continue;
@@ -323,7 +357,7 @@ async function getWindowActivitySessionsByKey(
         new Date(activity.ts),
         lastWindowActivity.activity,
         activeMinutesSet,
-        date
+        workdayStart
       );
       lastWindowActivity = activity;
     }
@@ -346,7 +380,7 @@ async function getWindowActivitySessionsByKey(
       end,
       lastWindowActivity.activity,
       activeMinutesSet,
-      date
+      workdayStart
     );
   }
 
@@ -643,26 +677,47 @@ function isRelevantTopItem(session: ActivitySessions): boolean {
  */
 export async function getLongestTimeActiveInsight(date: Date): Promise<TimeActive> {
   const activeMinutesSet = await getActiveMinutesSet(date); // encoded from 0 to 1439
+  const workdayStart = getRetrospectionWorkdayRange(date).start;
 
   let longest: TimeActive = { from: new Date(), to: new Date(), duration: -1 };
   let periodStart: number | undefined = undefined;
   for (let m = 0; m < 24 * 60; m++) {
-    if (activeMinutesSet.has(m) && !periodStart) {
+    if (activeMinutesSet.has(m) && periodStart === undefined) {
       periodStart = m;
-    } else if (!activeMinutesSet.has(m) && periodStart) {
+    } else if (!activeMinutesSet.has(m) && periodStart !== undefined) {
       const duration = m - periodStart;
       if (duration > longest.duration) {
         longest = {
-          from: getDateFromMinuteOfDay(periodStart, date),
-          to: getDateFromMinuteOfDay(m, date),
+          from: getDateFromWorkdayMinuteIndex(periodStart, workdayStart),
+          to: getDateFromWorkdayMinuteIndex(m, workdayStart),
           duration
         };
       }
       periodStart = undefined;
     }
   }
+  if (periodStart !== undefined) {
+    const duration = 24 * 60 - periodStart;
+    if (duration > longest.duration) {
+      longest = {
+        from: getDateFromWorkdayMinuteIndex(periodStart, workdayStart),
+        to: getDateFromWorkdayMinuteIndex(24 * 60, workdayStart),
+        duration
+      };
+    }
+  }
 
   return longest;
+}
+
+/**
+ * Total time with detected user input during the 04:00-to-04:00 workday.
+ */
+export async function getActiveHoursInsight(date: Date): Promise<ActiveHoursInsight> {
+  const activeMinutesSet = await getActiveMinutesSet(date);
+  return {
+    activeDurationMs: activeMinutesSet.size * 60000
+  };
 }
 
 /**

--- a/src/electron/electron/main/services/RetrospectionService.ts
+++ b/src/electron/electron/main/services/RetrospectionService.ts
@@ -2,6 +2,7 @@ import { UserInputEntity } from '../entities/UserInputEntity';
 import { WindowActivityEntity } from '../entities/WindowActivityEntity';
 import { getMainLogger } from '../../config/Logger';
 import { Activity, type ActiveHoursInsight } from '../../../src/utils/retrospection/types';
+import { formatSqliteLocalDateTime } from './utils/helpers';
 
 const LOG = getMainLogger('RetrospectionService');
 
@@ -120,22 +121,6 @@ export function isBrowserProcessName(processName: string | null): boolean {
   return BROWSER_PROCESS_NAME_PARTS.some(
     (browser) => normalizedProcessName.includes(normalizeProcessName(browser)) && browser.length > 3
   );
-}
-
-/**
- * Formats a date as a SQLite-local datetime string.
- *
- * Retrospection queries compare against `datetime(..., 'localtime')`, so parameters must be local
- * wall-clock timestamps instead of UTC ISO strings.
- */
-function formatSqliteLocalDateTime(date: Date): string {
-  const year = date.getFullYear();
-  const month = `${date.getMonth() + 1}`.padStart(2, '0');
-  const day = `${date.getDate()}`.padStart(2, '0');
-  const hours = `${date.getHours()}`.padStart(2, '0');
-  const minutes = `${date.getMinutes()}`.padStart(2, '0');
-  const seconds = `${date.getSeconds()}`.padStart(2, '0');
-  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 }
 
 /**

--- a/src/electron/electron/main/services/utils/helpers.ts
+++ b/src/electron/electron/main/services/utils/helpers.ts
@@ -24,3 +24,19 @@ export function generateAlphaNumericString(length: number = 0): string {
   }
   return result;
 }
+
+/**
+ * Formats a date as a SQLite-local datetime string.
+ *
+ * Queries that compare against `datetime(..., 'localtime')` need local wall-clock parameters
+ * instead of UTC ISO strings.
+ */
+export function formatSqliteLocalDateTime(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  const hours = `${date.getHours()}`.padStart(2, '0');
+  const minutes = `${date.getMinutes()}`.padStart(2, '0');
+  const seconds = `${date.getSeconds()}`.padStart(2, '0');
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+}

--- a/src/electron/src/utils/Commands.ts
+++ b/src/electron/src/utils/Commands.ts
@@ -11,7 +11,7 @@ import type {
   DailySurveySamplingType,
   ExperienceSamplingAnswerType
 } from '../../shared/StudyConfiguration';
-import type { ActivitySessions, TimeActive } from './retrospection/types';
+import type { ActiveHoursInsight, ActivitySessions, TimeActive } from './retrospection/types';
 
 type Commands = {
   createExperienceSample: (
@@ -55,6 +55,7 @@ type Commands = {
   startAllTrackers: () => void;
   triggerPermissionCheckAccessibility: (prompt: boolean) => boolean;
   triggerPermissionCheckScreenRecording: () => boolean;
+  retrospectionGetActiveHours: (date: Date) => Promise<ActiveHoursInsight>;
   retrospectionGetActivities: (date: Date) => Promise<ActivitySessions[]>;
   retrospectionLoadLongestTimeActive: (date: Date) => Promise<TimeActive | undefined>;
   retrospectionGetTopThreeMostActiveApps: (date: Date) => Promise<ActivitySessions[]>;

--- a/src/electron/src/utils/retrospection/types.ts
+++ b/src/electron/src/utils/retrospection/types.ts
@@ -49,6 +49,10 @@ export interface TimeActive {
   duration: number;
 }
 
+export interface ActiveHoursInsight {
+  activeDurationMs: number;
+}
+
 export interface ActivitySessions {
   type: string;
   totalDurationMs: number;

--- a/src/electron/src/utils/retrospection/utils.ts
+++ b/src/electron/src/utils/retrospection/utils.ts
@@ -25,6 +25,10 @@ export function msToReadableFormat(
     : `${formatWithoutSeconds}`
 }
 
+export function msToDecimalHours(durationInMs: number): string {
+  return `${(durationInMs / 3600000).toFixed(1)} hours`
+}
+
 const ACTIVITY_GROUPS: Record<string, Activity[]> = {
   Development: [Activity.DevCode, Activity.DevDebug, Activity.DevReview, Activity.DevVc],
   Planning: [Activity.Planning],

--- a/src/electron/src/views/RetrospectionView.vue
+++ b/src/electron/src/views/RetrospectionView.vue
@@ -13,6 +13,7 @@ import {
 import {
   ACTIVITY_LABELS,
   getActivityGroupFromActivityName,
+  msToDecimalHours,
   getTailwindClassFromActivity
 } from '../utils/retrospection/utils';
 import StackedBarChart from '../components/StackedBarChart.vue';
@@ -289,10 +290,6 @@ function renderCompactTime(ms: number): string {
   return remainingMinutes ? `${hours} hr ${remainingMinutes} min` : `${hours} hr`;
 }
 
-function renderDecimalHours(ms: number): string {
-  return `${(ms / 3600000).toFixed(1)} hours`;
-}
-
 function getTopItemWidth(item: ActivitySessions, items: ActivitySessions[]): string {
   const maxDurationMs = Math.max(...items.map((topItem) => topItem.totalDurationMs), 1);
   return `${Math.max((item.totalDurationMs / maxDurationMs) * 100, 8)}%`;
@@ -518,14 +515,14 @@ function getDayLabel(date: Date): string {
               <div>
                 <dt class="inline">Active on the computer:</dt>
                 <dd class="ml-1 inline">
-                  <b>{{ renderDecimalHours(activeHoursInsight?.activeDurationMs ?? 0) }}</b>
+                  <b>{{ msToDecimalHours(activeHoursInsight?.activeDurationMs ?? 0) }}</b>
                 </dd>
               </div>
               <div>
                 <dt class="inline">Spanning work:</dt>
                 <dd class="ml-1 inline">
                   <b>{{
-                    renderDecimalHours(latestUserComputerActivity - earliestUserComputerActivity)
+                    msToDecimalHours(latestUserComputerActivity - earliestUserComputerActivity)
                   }}</b>
                   (between {{ getTimeString(earliestUserComputerActivity) }} and
                   {{ getTimeString(latestUserComputerActivity) }})

--- a/src/electron/src/views/RetrospectionView.vue
+++ b/src/electron/src/views/RetrospectionView.vue
@@ -4,6 +4,7 @@ import {
   Activity,
   Color,
   DataPointType,
+  type ActiveHoursInsight,
   type ActivitySessions,
   type ChartDataPoint,
   type PieChartDataPoint,
@@ -22,6 +23,7 @@ const selectedDay = ref(new Date());
 const allWindowActivities = ref<ActivitySessions[]>([]);
 const chartDataWindowActivities = ref<ChartDataPoint[]>();
 const longestTimeActive = ref<TimeActive | undefined>(undefined);
+const activeHoursInsight = ref<ActiveHoursInsight | undefined>(undefined);
 const topApps = ref<ActivitySessions[] | undefined>(undefined);
 const topWebsites = ref<ActivitySessions[]>([]);
 const topWindowTitles = ref<ActivitySessions[]>([]);
@@ -159,6 +161,7 @@ onMounted(async () => {
 
 async function loadData() {
   isLoading.value = true;
+  await loadActiveHours();
   await loadLongestTimeActive();
   await loadMostActiveApps();
   await loadTopWebsites();
@@ -191,6 +194,17 @@ async function loadWindowActivities() {
     selectedDay.value
   )) as ActivitySessions[];
   windowActivitiesToChartData();
+}
+
+async function loadActiveHours() {
+  try {
+    activeHoursInsight.value = (await typedIpcRenderer.invoke(
+      'retrospectionGetActiveHours',
+      selectedDay.value
+    )) as ActiveHoursInsight;
+  } catch (error) {
+    console.error('Error loading active hours', error);
+  }
 }
 
 async function loadLongestTimeActive() {
@@ -275,6 +289,10 @@ function renderCompactTime(ms: number): string {
   return remainingMinutes ? `${hours} hr ${remainingMinutes} min` : `${hours} hr`;
 }
 
+function renderDecimalHours(ms: number): string {
+  return `${(ms / 3600000).toFixed(1)} hours`;
+}
+
 function getTopItemWidth(item: ActivitySessions, items: ActivitySessions[]): string {
   const maxDurationMs = Math.max(...items.map((topItem) => topItem.totalDurationMs), 1);
   return `${Math.max((item.totalDurationMs / maxDurationMs) * 100, 8)}%`;
@@ -289,8 +307,20 @@ function getTopItemColor(item: ActivitySessions): string {
 async function handleDayChange(event: Event) {
   const value = (event.target as HTMLInputElement).value;
   if (!value) return;
-  selectedDay.value = new Date(value);
+  selectedDay.value = parseDateInputValue(value);
   await loadData();
+}
+
+function parseDateInputValue(value: string): Date {
+  const [year, month, day] = value.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function formatDateInputValue(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 const isToday = computed(() => {
@@ -383,8 +413,8 @@ function getDayLabel(date: Date): string {
         </button>
         <input
           type="date"
-          :value="selectedDay.toISOString().substring(0, 10)"
-          :max="new Date().toISOString().substring(0, 10)"
+          :value="formatDateInputValue(selectedDay)"
+          :max="formatDateInputValue(new Date())"
           class="h-8 rounded border border-gray-300 bg-white px-2 text-gray-800 dark:border-neutral-600 dark:bg-neutral-700 dark:text-slate-200"
           style="min-width: 140px"
           @change="handleDayChange"
@@ -424,8 +454,8 @@ function getDayLabel(date: Date): string {
         </button>
         <input
           type="date"
-          :value="selectedDay.toISOString().substring(0, 10)"
-          :max="new Date().toISOString().substring(0, 10)"
+          :value="formatDateInputValue(selectedDay)"
+          :max="formatDateInputValue(new Date())"
           class="h-8 rounded border border-gray-300 bg-white px-2 text-gray-800 dark:border-neutral-600 dark:bg-neutral-700 dark:text-slate-200"
           style="min-width: 140px"
           @change="handleDayChange"
@@ -483,13 +513,25 @@ function getDayLabel(date: Date): string {
             v-if="chartDataWindowActivities?.length"
             class="rounded border border-gray-200 bg-gray-100 px-4 py-3 text-gray-800 dark:border-transparent dark:bg-neutral-800 dark:text-slate-200"
           >
-            <h2 class="primary-blue font-bold leading-4">Active hours on computer</h2>
-            <p class="mt-2">
-              You were active for
-              <b>{{ renderTime(latestUserComputerActivity - earliestUserComputerActivity) }}</b>
-              (between {{ getTimeString(earliestUserComputerActivity) }} and
-              {{ getTimeString(latestUserComputerActivity) }}).
-            </p>
+            <h2 class="primary-blue font-bold leading-4">Active hours</h2>
+            <dl class="mt-2 space-y-1">
+              <div>
+                <dt class="inline">Active on the computer:</dt>
+                <dd class="ml-1 inline">
+                  <b>{{ renderDecimalHours(activeHoursInsight?.activeDurationMs ?? 0) }}</b>
+                </dd>
+              </div>
+              <div>
+                <dt class="inline">Spanning work:</dt>
+                <dd class="ml-1 inline">
+                  <b>{{
+                    renderDecimalHours(latestUserComputerActivity - earliestUserComputerActivity)
+                  }}</b>
+                  (between {{ getTimeString(earliestUserComputerActivity) }} and
+                  {{ getTimeString(latestUserComputerActivity) }})
+                </dd>
+              </div>
+            </dl>
           </div>
 
           <!-- Tile 3: Top apps -->


### PR DESCRIPTION
# Refine Active Hours in Retrospection (Closes #513)

## Description

Refines the Retrospection `Active hours` card so it distinguishes actual computer activity from the overall work span. The card now shows active time based on detected user-input minutes, while still showing the existing first-to-last activity span for context.

### Changes Made

- Renamed the card title to `Active hours`
- Added `Active on the computer`, calculated from active user-input minutes
- Kept the existing span metric as `Spanning work`
- Shows the span time range, e.g. `between 07:25 and 14:51`
- Reuses the SelfReflection active-minute logic based on clicks, keys, scrolling, or mouse movement
- Applies a 04:00 workday cutoff so late-night work before 04:00 belongs to the previous workday
- Updates Retrospection activity queries to use the 04:00-to-04:00 workday window
- Fixes Retrospection date-picker handling to use local dates
- Adds tests for the 04:00 workday cutoff and late-night minute indexing

Closes #513