### PR TITLE
Retrospection: Fix Timeline Detail App Icons (Closes #552)

### DIFF
--- a/src/electron/electron-builder.config.cjs
+++ b/src/electron/electron-builder.config.cjs
@@ -2,7 +2,11 @@ module.exports = {
   productName: 'PersonalAnalytics',
   appId: 'ch.ifi.hasel.personal-analytics',
   asar: true,
-  asarUnpack: ['node_modules/better_sqlite3/**', 'node_modules/sqlite3/**'],
+  asarUnpack: [
+    'node_modules/better_sqlite3/**',
+    'node_modules/sqlite3/**',
+    'node_modules/extract-file-icon/**'
+  ],
   directories: {
     output: 'release/${version}'
   },

--- a/src/electron/electron/main/__tests__/AppIconHelper.test.ts
+++ b/src/electron/electron/main/__tests__/AppIconHelper.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, expect, jest, test } from '@jest/globals';
+
+const WORD_PROCESS_PATH = 'C:\\Program Files\\Microsoft Office\\root\\Office16\\WINWORD.EXE';
+const WORD_MANIFEST_PATH =
+  'C:\\Program Files\\Microsoft Office\\root\\Office16\\WINWORD.VisualElementsManifest.xml';
+const WORD_ASSETS_DIRECTORY = 'C:\\Program Files\\Microsoft Office\\root\\Office16\\Assets';
+const WORD_TARGET_ICON_PATH =
+  'C:\\Program Files\\Microsoft Office\\root\\Office16\\Assets\\WordLogo.targetsize-32.png';
+const SHELL_ICON_PROCESS_PATH = 'C:\\Tools\\ShellIconApp\\ShellIconApp.exe';
+const SHELL_ICON_DATA_URL = 'data:image/png;base64,shell';
+const MAC_WORD_PROCESS_PATH = '/Applications/Microsoft Word.app/Contents/MacOS/Microsoft Word';
+const MAC_WORD_INFO_PLIST_PATH = '/Applications/Microsoft Word.app/Contents/Info.plist';
+const MAC_WORD_RESOURCES_PATH = '/Applications/Microsoft Word.app/Contents/Resources';
+const MAC_WORD_ICON_PATH = '/Applications/Microsoft Word.app/Contents/Resources/Word_macOS.icns';
+const SIPS_TEMP_DIRECTORY = '/tmp/personal-analytics-icon-test';
+const SIPS_PNG_PATH = '/tmp/personal-analytics-icon-test/icon.png';
+
+const getFileIconMock = jest.fn((filePath: string) =>
+  Promise.resolve({
+    isEmpty: () => filePath !== SHELL_ICON_PROCESS_PATH,
+    resize: () => ({
+      toDataURL: () => SHELL_ICON_DATA_URL
+    })
+  })
+);
+
+const resizeMock = jest.fn(() => ({
+  toDataURL: () => 'data:image/png;base64,word'
+}));
+
+const createFromPathMock = jest.fn((iconPath: string) => ({
+  isEmpty: () => iconPath !== WORD_TARGET_ICON_PATH,
+  resize: resizeMock
+}));
+
+const createFromBufferResizeMock = jest.fn(() => ({
+  toDataURL: () => 'data:image/png;base64,mac-word'
+}));
+
+const createFromBufferMock = jest.fn(() => ({
+  isEmpty: () => false,
+  resize: createFromBufferResizeMock
+}));
+
+const existsSyncMock = jest.fn((filePath: string) => {
+  return [
+    WORD_MANIFEST_PATH,
+    WORD_ASSETS_DIRECTORY,
+    WORD_TARGET_ICON_PATH,
+    MAC_WORD_INFO_PLIST_PATH,
+    MAC_WORD_RESOURCES_PATH,
+    MAC_WORD_ICON_PATH
+  ].includes(filePath.toString());
+});
+
+const readFileSyncMock = jest.fn((filePath: string) => {
+  if (filePath.toString() === MAC_WORD_INFO_PLIST_PATH) {
+    return `
+      <plist>
+        <dict>
+          <key>CFBundleIconFile</key>
+          <string>Word_macOS</string>
+        </dict>
+      </plist>
+    `;
+  }
+
+  if (filePath.toString() === SIPS_PNG_PATH) {
+    return Buffer.from('converted-png');
+  }
+
+  if (filePath.toString() === WORD_MANIFEST_PATH) {
+    return `
+      <Application>
+        <VisualElements
+          Square44x44Logo="Assets\\WordLogo.png"
+          Square150x150Logo="Assets\\WordTile.png"
+          ShowNameOnSquare150x150Logo="on" />
+      </Application>
+    `;
+  }
+
+  throw new Error(`Unexpected file read: ${filePath.toString()}`);
+});
+
+const readdirSyncMock = jest.fn((directoryPath: string) => {
+  if (directoryPath.toString() === MAC_WORD_RESOURCES_PATH) {
+    return ['Word_macOS.icns', 'WXBN.icns'];
+  }
+
+  if (directoryPath.toString() !== WORD_ASSETS_DIRECTORY) {
+    throw new Error(`Unexpected directory read: ${directoryPath.toString()}`);
+  }
+
+  return ['WordLogo.scale-200.png', 'WordLogo.targetsize-32.png', 'WordLogo.targetsize-16.png'];
+});
+
+const mkdtempSyncMock = jest.fn(() => SIPS_TEMP_DIRECTORY);
+const rmSyncMock = jest.fn();
+const execFileSyncMock = jest.fn();
+
+jest.unstable_mockModule('electron', () => ({
+  app: {
+    getFileIcon: getFileIconMock
+  },
+  nativeImage: {
+    createFromPath: createFromPathMock,
+    createFromBuffer: createFromBufferMock
+  },
+  default: {
+    app: {
+      isPackaged: false
+    }
+  }
+}));
+
+jest.unstable_mockModule('node:fs', () => ({
+  existsSync: existsSyncMock,
+  mkdtempSync: mkdtempSyncMock,
+  readFileSync: readFileSyncMock,
+  readdirSync: readdirSyncMock,
+  rmSync: rmSyncMock
+}));
+
+jest.unstable_mockModule('node:child_process', () => ({
+  execFileSync: execFileSyncMock
+}));
+
+const { getProcessIconDataUrl } = await import('../services/utils/AppIconHelper');
+
+beforeEach(() => {
+  getFileIconMock.mockClear();
+  createFromPathMock.mockClear();
+  resizeMock.mockClear();
+  createFromBufferMock.mockClear();
+  createFromBufferResizeMock.mockClear();
+  existsSyncMock.mockClear();
+  readFileSyncMock.mockClear();
+  readdirSyncMock.mockClear();
+  mkdtempSyncMock.mockClear();
+  rmSyncMock.mockClear();
+  execFileSyncMock.mockClear();
+});
+
+test('uses Windows visual elements assets when the executable icon is unavailable', async () => {
+  await expect(getProcessIconDataUrl(WORD_PROCESS_PATH, 'Microsoft Word')).resolves.toBe(
+    'data:image/png;base64,word'
+  );
+  expect(createFromPathMock).toHaveBeenCalledWith(WORD_TARGET_ICON_PATH);
+  expect(resizeMock).toHaveBeenCalledWith({ width: 64, height: 64 });
+});
+
+test('falls back to the Electron shell icon when no Windows visual elements manifest exists', async () => {
+  await expect(getProcessIconDataUrl(SHELL_ICON_PROCESS_PATH, 'Shell Icon App')).resolves.toBe(
+    SHELL_ICON_DATA_URL
+  );
+  expect(getFileIconMock).toHaveBeenCalledWith(SHELL_ICON_PROCESS_PATH, { size: 'small' });
+});
+
+test('converts macOS icns app icons when Electron cannot load them directly', async () => {
+  await expect(getProcessIconDataUrl(MAC_WORD_PROCESS_PATH, 'Microsoft Word')).resolves.toBe(
+    'data:image/png;base64,mac-word'
+  );
+  expect(createFromPathMock).toHaveBeenCalledWith(MAC_WORD_ICON_PATH);
+  expect(execFileSyncMock).toHaveBeenCalledWith(
+    '/usr/bin/sips',
+    ['-s', 'format', 'png', '--out', SIPS_PNG_PATH, MAC_WORD_ICON_PATH],
+    { stdio: 'ignore' }
+  );
+  expect(createFromBufferMock).toHaveBeenCalledWith(Buffer.from('converted-png'));
+  expect(createFromBufferResizeMock).toHaveBeenCalledWith({ width: 64, height: 64 });
+  expect(rmSyncMock).toHaveBeenCalledWith(SIPS_TEMP_DIRECTORY, { recursive: true, force: true });
+});

--- a/src/electron/electron/main/__tests__/AppIconHelper.test.ts
+++ b/src/electron/electron/main/__tests__/AppIconHelper.test.ts
@@ -12,13 +12,41 @@ const OUTLOOK_PROCESS_PATH = 'C:\\Program Files\\Microsoft Office\\root\\Office1
 const TEAMS_PROCESS_PATH = 'C:\\Users\\test\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe';
 const GITHUB_DESKTOP_PROCESS_PATH =
   'C:\\Users\\test\\AppData\\Local\\GitHubDesktop\\GitHubDesktop.exe';
+const WINDOWS_APPS_FILE_ICON_PROCESS_PATH =
+  'C:\\Program Files\\WindowsApps\\FallbackApp_1.0.0.0_x64__test\\FallbackApp.exe';
+const WINDOWS_APPS_TEAMS_PROCESS_PATH =
+  'C:\\Program Files\\WindowsApps\\MSTeams_26163.407.4851.7751_x64__8wekyb3d8bbwe\\ms-teams.exe';
+const WINDOWS_APPS_WHATSAPP_PROCESS_PATH =
+  'C:\\Program Files\\WindowsApps\\5319275A.WhatsAppDesktop_2.2625.101.0_x64__cv1g1gvanyjgm\\WhatsApp.Root.exe';
+const WINDOWS_APPS_CLAUDE_PROCESS_PATH =
+  'C:\\Program Files\\WindowsApps\\Claude_1.14271.0.0_x64__pzs8sxrjxfjjc\\app\\Claude.exe';
+const WINDOWS_APPS_PACKAGE_ICON_CASES = [
+  {
+    name: 'Microsoft Teams',
+    processPath: WINDOWS_APPS_TEAMS_PROCESS_PATH,
+    processId: 11064
+  },
+  {
+    name: 'WhatsApp',
+    processPath: WINDOWS_APPS_WHATSAPP_PROCESS_PATH,
+    processId: 21800
+  },
+  {
+    name: 'Claude',
+    processPath: WINDOWS_APPS_CLAUDE_PROCESS_PATH,
+    processId: 35132
+  }
+];
 const WINDOWS_NATIVE_ICON_PROCESS_PATHS = [
   OUTLOOK_PROCESS_PATH,
   TEAMS_PROCESS_PATH,
-  GITHUB_DESKTOP_PROCESS_PATH
+  GITHUB_DESKTOP_PROCESS_PATH,
+  WINDOWS_APPS_FILE_ICON_PROCESS_PATH
 ];
 const NATIVE_ICON_BUFFER = Buffer.from('native-file-icon');
 const NATIVE_ICON_DATA_URL = 'data:image/png;base64,native-file-icon';
+const WINDOWS_APPS_PACKAGE_ICON_BUFFER = Buffer.from('windows-app-package-icon');
+const WINDOWS_APPS_PACKAGE_ICON_DATA_URL = 'data:image/png;base64,windows-app-package-icon';
 const MAC_WORD_PROCESS_PATH = '/Applications/Microsoft Word.app/Contents/MacOS/Microsoft Word';
 const MAC_WORD_INFO_PLIST_PATH = '/Applications/Microsoft Word.app/Contents/Info.plist';
 const MAC_WORD_RESOURCES_PATH = '/Applications/Microsoft Word.app/Contents/Resources';
@@ -49,21 +77,39 @@ const createFromPathMock = jest.fn((iconPath: string) => ({
 const createFromBufferMock = jest.fn((buffer: Buffer) => ({
   isEmpty: () => false,
   resize: () => ({
-    toDataURL: () =>
-      buffer.equals(NATIVE_ICON_BUFFER) ? NATIVE_ICON_DATA_URL : 'data:image/png;base64,mac-word'
+    toDataURL: () => {
+      if (buffer.equals(NATIVE_ICON_BUFFER)) {
+        return NATIVE_ICON_DATA_URL;
+      }
+
+      if (buffer.equals(WINDOWS_APPS_PACKAGE_ICON_BUFFER)) {
+        return WINDOWS_APPS_PACKAGE_ICON_DATA_URL;
+      }
+
+      return 'data:image/png;base64,mac-word';
+    }
   })
 }));
 
-const extractFileIconMock = jest.fn((iconPath: string) => {
-  if (
-    WINDOWS_NATIVE_ICON_PROCESS_PATHS.includes(iconPath) ||
-    iconPath === MAC_TEAMS_APP_BUNDLE_PATH
-  ) {
-    return NATIVE_ICON_BUFFER;
-  }
-
-  return undefined;
+const getPackageIconMock = jest.fn((_: number, processPath: string) => {
+  return WINDOWS_APPS_PACKAGE_ICON_CASES.some((app) => app.processPath === processPath)
+    ? WINDOWS_APPS_PACKAGE_ICON_BUFFER
+    : undefined;
 });
+
+const extractFileIconMock = Object.assign(
+  jest.fn((iconPath: string) => {
+    if (
+      WINDOWS_NATIVE_ICON_PROCESS_PATHS.includes(iconPath) ||
+      iconPath === MAC_TEAMS_APP_BUNDLE_PATH
+    ) {
+      return NATIVE_ICON_BUFFER;
+    }
+
+    return undefined;
+  }),
+  { getPackageIcon: getPackageIconMock }
+);
 
 const existsSyncMock = jest.fn((filePath: string) => {
   return [
@@ -160,6 +206,7 @@ beforeEach(() => {
   createFromPathMock.mockClear();
   resizeMock.mockClear();
   createFromBufferMock.mockClear();
+  getPackageIconMock.mockClear();
   extractFileIconMock.mockClear();
   existsSyncMock.mockClear();
   readFileSyncMock.mockClear();
@@ -180,7 +227,8 @@ test('uses Windows visual elements assets when the executable icon is unavailabl
 test.each([
   ['Microsoft Outlook', OUTLOOK_PROCESS_PATH],
   ['Microsoft Teams', TEAMS_PROCESS_PATH],
-  ['GitHub Desktop', GITHUB_DESKTOP_PROCESS_PATH]
+  ['GitHub Desktop', GITHUB_DESKTOP_PROCESS_PATH],
+  ['Windows App Package Fallback', WINDOWS_APPS_FILE_ICON_PROCESS_PATH]
 ])(
   'uses the native file icon extractor for %s before Windows fallback assets',
   async (name, path) => {
@@ -191,6 +239,27 @@ test.each([
     expect(getFileIconMock).not.toHaveBeenCalled();
   }
 );
+
+test.each(WINDOWS_APPS_PACKAGE_ICON_CASES)(
+  'uses the Windows package icon for $name installed under WindowsApps',
+  async ({ name, processPath, processId }) => {
+    await expect(getProcessIconDataUrl(processPath, name, processId)).resolves.toBe(
+      WINDOWS_APPS_PACKAGE_ICON_DATA_URL
+    );
+    expect(getPackageIconMock).toHaveBeenCalledWith(processId, processPath, 16);
+    expect(createFromBufferMock).toHaveBeenCalledWith(WINDOWS_APPS_PACKAGE_ICON_BUFFER);
+    expect(extractFileIconMock).not.toHaveBeenCalled();
+    expect(createFromPathMock).not.toHaveBeenCalled();
+    expect(getFileIconMock).not.toHaveBeenCalled();
+  }
+);
+
+test('uses the Windows package icon without a live process ID', async () => {
+  await expect(getProcessIconDataUrl(WINDOWS_APPS_CLAUDE_PROCESS_PATH, 'Claude')).resolves.toBe(
+    WINDOWS_APPS_PACKAGE_ICON_DATA_URL
+  );
+  expect(getPackageIconMock).toHaveBeenCalledWith(0, WINDOWS_APPS_CLAUDE_PROCESS_PATH, 16);
+});
 
 test('falls back to the Electron shell icon when no Windows visual elements manifest exists', async () => {
   await expect(getProcessIconDataUrl(SHELL_ICON_PROCESS_PATH, 'Shell Icon App')).resolves.toBe(

--- a/src/electron/electron/main/__tests__/AppIconHelper.test.ts
+++ b/src/electron/electron/main/__tests__/AppIconHelper.test.ts
@@ -8,10 +8,23 @@ const WORD_TARGET_ICON_PATH =
   'C:\\Program Files\\Microsoft Office\\root\\Office16\\Assets\\WordLogo.targetsize-32.png';
 const SHELL_ICON_PROCESS_PATH = 'C:\\Tools\\ShellIconApp\\ShellIconApp.exe';
 const SHELL_ICON_DATA_URL = 'data:image/png;base64,shell';
+const OUTLOOK_PROCESS_PATH = 'C:\\Program Files\\Microsoft Office\\root\\Office16\\OUTLOOK.EXE';
+const TEAMS_PROCESS_PATH = 'C:\\Users\\test\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe';
+const GITHUB_DESKTOP_PROCESS_PATH =
+  'C:\\Users\\test\\AppData\\Local\\GitHubDesktop\\GitHubDesktop.exe';
+const WINDOWS_NATIVE_ICON_PROCESS_PATHS = [
+  OUTLOOK_PROCESS_PATH,
+  TEAMS_PROCESS_PATH,
+  GITHUB_DESKTOP_PROCESS_PATH
+];
+const NATIVE_ICON_BUFFER = Buffer.from('native-file-icon');
+const NATIVE_ICON_DATA_URL = 'data:image/png;base64,native-file-icon';
 const MAC_WORD_PROCESS_PATH = '/Applications/Microsoft Word.app/Contents/MacOS/Microsoft Word';
 const MAC_WORD_INFO_PLIST_PATH = '/Applications/Microsoft Word.app/Contents/Info.plist';
 const MAC_WORD_RESOURCES_PATH = '/Applications/Microsoft Word.app/Contents/Resources';
 const MAC_WORD_ICON_PATH = '/Applications/Microsoft Word.app/Contents/Resources/Word_macOS.icns';
+const MAC_TEAMS_PROCESS_PATH = '/Applications/Microsoft Teams.app/Contents/MacOS/Microsoft Teams';
+const MAC_TEAMS_APP_BUNDLE_PATH = '/Applications/Microsoft Teams.app';
 const SIPS_TEMP_DIRECTORY = '/tmp/personal-analytics-icon-test';
 const SIPS_PNG_PATH = '/tmp/personal-analytics-icon-test/icon.png';
 
@@ -33,14 +46,24 @@ const createFromPathMock = jest.fn((iconPath: string) => ({
   resize: resizeMock
 }));
 
-const createFromBufferResizeMock = jest.fn(() => ({
-  toDataURL: () => 'data:image/png;base64,mac-word'
+const createFromBufferMock = jest.fn((buffer: Buffer) => ({
+  isEmpty: () => false,
+  resize: () => ({
+    toDataURL: () =>
+      buffer.equals(NATIVE_ICON_BUFFER) ? NATIVE_ICON_DATA_URL : 'data:image/png;base64,mac-word'
+  })
 }));
 
-const createFromBufferMock = jest.fn(() => ({
-  isEmpty: () => false,
-  resize: createFromBufferResizeMock
-}));
+const extractFileIconMock = jest.fn((iconPath: string) => {
+  if (
+    WINDOWS_NATIVE_ICON_PROCESS_PATHS.includes(iconPath) ||
+    iconPath === MAC_TEAMS_APP_BUNDLE_PATH
+  ) {
+    return NATIVE_ICON_BUFFER;
+  }
+
+  return undefined;
+});
 
 const existsSyncMock = jest.fn((filePath: string) => {
   return [
@@ -126,6 +149,10 @@ jest.unstable_mockModule('node:child_process', () => ({
   execFileSync: execFileSyncMock
 }));
 
+jest.unstable_mockModule('extract-file-icon', () => ({
+  default: extractFileIconMock
+}));
+
 const { getProcessIconDataUrl } = await import('../services/utils/AppIconHelper');
 
 beforeEach(() => {
@@ -133,7 +160,7 @@ beforeEach(() => {
   createFromPathMock.mockClear();
   resizeMock.mockClear();
   createFromBufferMock.mockClear();
-  createFromBufferResizeMock.mockClear();
+  extractFileIconMock.mockClear();
   existsSyncMock.mockClear();
   readFileSyncMock.mockClear();
   readdirSyncMock.mockClear();
@@ -147,8 +174,23 @@ test('uses Windows visual elements assets when the executable icon is unavailabl
     'data:image/png;base64,word'
   );
   expect(createFromPathMock).toHaveBeenCalledWith(WORD_TARGET_ICON_PATH);
-  expect(resizeMock).toHaveBeenCalledWith({ width: 64, height: 64 });
+  expect(resizeMock).toHaveBeenCalledWith({ width: 16, height: 16 });
 });
+
+test.each([
+  ['Microsoft Outlook', OUTLOOK_PROCESS_PATH],
+  ['Microsoft Teams', TEAMS_PROCESS_PATH],
+  ['GitHub Desktop', GITHUB_DESKTOP_PROCESS_PATH]
+])(
+  'uses the native file icon extractor for %s before Windows fallback assets',
+  async (name, path) => {
+    await expect(getProcessIconDataUrl(path, name)).resolves.toBe(NATIVE_ICON_DATA_URL);
+    expect(extractFileIconMock).toHaveBeenCalledWith(path, 16);
+    expect(createFromBufferMock).toHaveBeenCalledWith(NATIVE_ICON_BUFFER);
+    expect(createFromPathMock).not.toHaveBeenCalled();
+    expect(getFileIconMock).not.toHaveBeenCalled();
+  }
+);
 
 test('falls back to the Electron shell icon when no Windows visual elements manifest exists', async () => {
   await expect(getProcessIconDataUrl(SHELL_ICON_PROCESS_PATH, 'Shell Icon App')).resolves.toBe(
@@ -168,6 +210,12 @@ test('converts macOS icns app icons when Electron cannot load them directly', as
     { stdio: 'ignore' }
   );
   expect(createFromBufferMock).toHaveBeenCalledWith(Buffer.from('converted-png'));
-  expect(createFromBufferResizeMock).toHaveBeenCalledWith({ width: 64, height: 64 });
   expect(rmSyncMock).toHaveBeenCalledWith(SIPS_TEMP_DIRECTORY, { recursive: true, force: true });
+});
+
+test('uses the macOS app bundle with the native file icon extractor', async () => {
+  await expect(getProcessIconDataUrl(MAC_TEAMS_PROCESS_PATH, 'Microsoft Teams')).resolves.toBe(
+    NATIVE_ICON_DATA_URL
+  );
+  expect(extractFileIconMock).toHaveBeenCalledWith(MAC_TEAMS_APP_BUNDLE_PATH, 16);
 });

--- a/src/electron/electron/main/services/RetrospectionService.ts
+++ b/src/electron/electron/main/services/RetrospectionService.ts
@@ -752,7 +752,11 @@ async function addWindowActivityDetailSpan(
   }
 
   const tooltipTitle = getLongTimelineHoverTitle(activity, title);
-  const iconDataUrl = await getProcessIconDataUrl(activity.processPath, activity.processName);
+  const iconDataUrl = await getProcessIconDataUrl(
+    activity.processPath,
+    activity.processName,
+    activity.processId
+  );
   getActiveMinuteSpans(from, to, activeMinutesSet, workdayStart).forEach((span) => {
     spans.push({
       from: span.from,

--- a/src/electron/electron/main/services/utils/AppIconHelper.ts
+++ b/src/electron/electron/main/services/utils/AppIconHelper.ts
@@ -1,4 +1,5 @@
 import { app, nativeImage } from 'electron';
+import extractFileIcon from 'extract-file-icon';
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -7,7 +8,7 @@ import { getMainLogger } from '../../../config/Logger';
 
 const LOG = getMainLogger('AppIconHelper');
 const APP_ICON_DATA_URL_CACHE = new Map<string, Promise<string | undefined>>();
-const APP_ICON_SIZE = 64;
+const APP_ICON_SIZE = 16;
 const WINDOWS_LOGO_ATTRIBUTE_PRIORITY = [
   'Square44x44Logo',
   'SmallLogo',
@@ -243,6 +244,29 @@ function getIconDataUrlFromPath(iconPath: string | undefined): string | undefine
   return icon.resize({ width: APP_ICON_SIZE, height: APP_ICON_SIZE }).toDataURL();
 }
 
+function getNativeFileIconDataUrl(iconPath: string | undefined): string | undefined {
+  if (!iconPath) {
+    return undefined;
+  }
+
+  try {
+    const iconBuffer = extractFileIcon(iconPath, APP_ICON_SIZE);
+    if (!iconBuffer?.length) {
+      return undefined;
+    }
+
+    const icon = nativeImage.createFromBuffer(iconBuffer);
+    if (icon.isEmpty()) {
+      return undefined;
+    }
+
+    return icon.resize({ width: APP_ICON_SIZE, height: APP_ICON_SIZE }).toDataURL();
+  } catch (error) {
+    LOG.debug('Could not extract native app icon', iconPath, error);
+    return undefined;
+  }
+}
+
 function getMacIcnsDataUrlViaSips(iconPath: string): string | undefined {
   const tempDirectory = mkdtempSync(path.join(tmpdir(), 'personal-analytics-icon-'));
   const pngPath = path.join(tempDirectory, 'icon.png');
@@ -348,6 +372,11 @@ export async function getProcessIconDataUrl(
       if (personalAnalyticsIcon) {
         return personalAnalyticsIcon;
       }
+    }
+
+    const nativeFileIcon = getNativeFileIconDataUrl(appBundlePath || processPath);
+    if (nativeFileIcon) {
+      return nativeFileIcon;
     }
 
     if (appBundlePath) {

--- a/src/electron/electron/main/services/utils/AppIconHelper.ts
+++ b/src/electron/electron/main/services/utils/AppIconHelper.ts
@@ -54,6 +54,10 @@ function isWindowsProcessPath(processPath: string): boolean {
   return /^[a-zA-Z]:[\\/]/.test(processPath) || processPath.includes('\\');
 }
 
+function isWindowsAppsProcessPath(processPath: string): boolean {
+  return isWindowsProcessPath(processPath) && /[\\/]WindowsApps[\\/]/i.test(processPath);
+}
+
 function getPathModuleForProcessPath(processPath: string) {
   return isWindowsProcessPath(processPath) ? path.win32 : path;
 }
@@ -267,6 +271,32 @@ function getNativeFileIconDataUrl(iconPath: string | undefined): string | undefi
   }
 }
 
+function getWindowsAppsPackageIconDataUrl(
+  processPath: string | null,
+  processId: number | null
+): string | undefined {
+  if (!processPath || !isWindowsAppsProcessPath(processPath)) {
+    return undefined;
+  }
+
+  try {
+    const iconBuffer = extractFileIcon.getPackageIcon?.(processId ?? 0, processPath, APP_ICON_SIZE);
+    if (!iconBuffer?.length) {
+      return undefined;
+    }
+
+    const icon = nativeImage.createFromBuffer(iconBuffer);
+    if (icon.isEmpty()) {
+      return undefined;
+    }
+
+    return icon.resize({ width: APP_ICON_SIZE, height: APP_ICON_SIZE }).toDataURL();
+  } catch (error) {
+    LOG.debug('Could not extract Windows app package icon', processPath, error);
+    return undefined;
+  }
+}
+
 function getMacIcnsDataUrlViaSips(iconPath: string): string | undefined {
   const tempDirectory = mkdtempSync(path.join(tmpdir(), 'personal-analytics-icon-'));
   const pngPath = path.join(tempDirectory, 'icon.png');
@@ -353,9 +383,10 @@ function getBundleResourceIconDataUrl(
  */
 export async function getProcessIconDataUrl(
   processPath: string | null,
-  processName: string | null
+  processName: string | null,
+  processId: number | null = null
 ): Promise<string | undefined> {
-  const cacheKey = `${processPath || ''}\u0000${processName || ''}`;
+  const cacheKey = `${processPath || ''}\u0000${processName || ''}\u0000${processId ?? ''}`;
   const cachedIcon = APP_ICON_DATA_URL_CACHE.get(cacheKey);
   if (cachedIcon) {
     return cachedIcon;
@@ -372,6 +403,11 @@ export async function getProcessIconDataUrl(
       if (personalAnalyticsIcon) {
         return personalAnalyticsIcon;
       }
+    }
+
+    const windowsAppsPackageIcon = getWindowsAppsPackageIconDataUrl(processPath, processId);
+    if (windowsAppsPackageIcon) {
+      return windowsAppsPackageIcon;
     }
 
     const nativeFileIcon = getNativeFileIconDataUrl(appBundlePath || processPath);

--- a/src/electron/electron/main/services/utils/AppIconHelper.ts
+++ b/src/electron/electron/main/services/utils/AppIconHelper.ts
@@ -1,11 +1,40 @@
 import { app, nativeImage } from 'electron';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { getMainLogger } from '../../../config/Logger';
 
 const LOG = getMainLogger('AppIconHelper');
 const APP_ICON_DATA_URL_CACHE = new Map<string, Promise<string | undefined>>();
-const APP_ICON_SIZE = 16;
+const APP_ICON_SIZE = 64;
+const WINDOWS_LOGO_ATTRIBUTE_PRIORITY = [
+  'Square44x44Logo',
+  'SmallLogo',
+  'Square30x30Logo',
+  'Square32x32Logo',
+  'Square70x70Logo',
+  'Square71x71Logo',
+  'Square150x150Logo',
+  'Logo'
+];
+const WINDOWS_ASSET_VARIANT_PRIORITY = [
+  'targetsize-64',
+  'targetsize-48',
+  'targetsize-44',
+  'targetsize-40',
+  'targetsize-32',
+  'targetsize-30',
+  'targetsize-24',
+  'targetsize-20',
+  'targetsize-16',
+  'scale-100',
+  'scale-125',
+  'scale-150',
+  'scale-200',
+  'scale-400'
+];
+const WINDOWS_IMAGE_EXTENSIONS = new Set(['.ico', '.jpg', '.jpeg', '.png']);
 
 function normalizeIconName(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
@@ -18,6 +47,160 @@ function getMacAppBundlePath(processPath: string | null): string | null {
 
   const appBundleMatch = processPath.match(/^(.+?\.app)(?:\/|$)/);
   return appBundleMatch?.[1] || null;
+}
+
+function isWindowsProcessPath(processPath: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(processPath) || processPath.includes('\\');
+}
+
+function getPathModuleForProcessPath(processPath: string) {
+  return isWindowsProcessPath(processPath) ? path.win32 : path;
+}
+
+function uniqueStrings(values: (string | undefined)[]): string[] {
+  const seenValues = new Set<string>();
+  const uniqueValues: string[] = [];
+
+  values.forEach((value) => {
+    const trimmedValue = value?.trim();
+    if (!trimmedValue || seenValues.has(trimmedValue)) {
+      return;
+    }
+
+    seenValues.add(trimmedValue);
+    uniqueValues.push(trimmedValue);
+  });
+
+  return uniqueValues;
+}
+
+function decodeXmlAttributeValue(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
+function getXmlAttributeValue(xml: string, attributeName: string): string | undefined {
+  const attributeMatch = xml.match(new RegExp(`\\b${attributeName}\\s*=\\s*["']([^"']+)["']`, 'i'));
+  return attributeMatch?.[1] ? decodeXmlAttributeValue(attributeMatch[1]) : undefined;
+}
+
+function getWindowsVisualElementsManifestPaths(processPath: string | null): string[] {
+  if (!processPath || !isWindowsProcessPath(processPath)) {
+    return [];
+  }
+
+  const pathModule = getPathModuleForProcessPath(processPath);
+  const processPathParts = pathModule.parse(processPath);
+  if (!processPathParts.dir || !processPathParts.name) {
+    return [];
+  }
+
+  return uniqueStrings([
+    pathModule.join(processPathParts.dir, `${processPathParts.name}.VisualElementsManifest.xml`),
+    pathModule.join(
+      processPathParts.dir,
+      `${processPathParts.name.toUpperCase()}.VisualElementsManifest.xml`
+    ),
+    pathModule.join(
+      processPathParts.dir,
+      `${processPathParts.name.toLowerCase()}.VisualElementsManifest.xml`
+    )
+  ]);
+}
+
+function getWindowsManifestLogoPaths(manifestPath: string): string[] {
+  try {
+    const manifest = readFileSync(manifestPath, 'utf8');
+    const prioritizedLogoPaths = WINDOWS_LOGO_ATTRIBUTE_PRIORITY.map((attributeName) =>
+      getXmlAttributeValue(manifest, attributeName)
+    );
+    const discoveredLogoPaths = Array.from(
+      manifest.matchAll(/\b((?:[A-Za-z_][\w.-]*:)?[A-Za-z0-9]+Logo)\s*=\s*["']([^"']+)["']/gi)
+    )
+      .filter(([, attributeName]) => {
+        return !attributeName.split(':').pop()?.toLowerCase().startsWith('shownameon');
+      })
+      .map(([, , value]) => decodeXmlAttributeValue(value));
+
+    return uniqueStrings([...prioritizedLogoPaths, ...discoveredLogoPaths]);
+  } catch (error) {
+    LOG.debug('Could not read Windows visual elements manifest', manifestPath, error);
+    return [];
+  }
+}
+
+function getWindowsAssetVariantRank(fileName: string): number {
+  const normalizedFileName = fileName.toLowerCase();
+  const priorityIndex = WINDOWS_ASSET_VARIANT_PRIORITY.findIndex((priorityFragment) =>
+    normalizedFileName.includes(priorityFragment)
+  );
+
+  return priorityIndex === -1 ? WINDOWS_ASSET_VARIANT_PRIORITY.length : priorityIndex;
+}
+
+function getWindowsLogoCandidatePaths(manifestPath: string, logoPath: string): string[] {
+  const pathModule = getPathModuleForProcessPath(manifestPath);
+  const manifestDirectory = pathModule.dirname(manifestPath);
+  const absoluteLogoPath = pathModule.resolve(manifestDirectory, logoPath);
+  const logoPathParts = pathModule.parse(absoluteLogoPath);
+  const candidatePaths = [absoluteLogoPath];
+
+  if (!logoPathParts.dir || !existsSync(logoPathParts.dir)) {
+    return candidatePaths;
+  }
+
+  try {
+    const logoBaseName = logoPathParts.name.toLowerCase();
+    const logoExtension = logoPathParts.ext.toLowerCase();
+    const variantFiles = readdirSync(logoPathParts.dir)
+      .filter((file) => {
+        const fileParts = pathModule.parse(file);
+        const fileBaseName = fileParts.name.toLowerCase();
+        const fileExtension = fileParts.ext.toLowerCase();
+        const hasExpectedExtension = logoExtension
+          ? fileExtension === logoExtension
+          : WINDOWS_IMAGE_EXTENSIONS.has(fileExtension);
+
+        return (
+          hasExpectedExtension &&
+          (fileBaseName === logoBaseName || fileBaseName.startsWith(`${logoBaseName}.`))
+        );
+      })
+      .sort((firstFile, secondFile) => {
+        const rankDifference =
+          getWindowsAssetVariantRank(firstFile) - getWindowsAssetVariantRank(secondFile);
+        return rankDifference || firstFile.localeCompare(secondFile);
+      });
+
+    candidatePaths.push(...variantFiles.map((file) => pathModule.join(logoPathParts.dir, file)));
+  } catch (error) {
+    LOG.debug('Could not read Windows visual elements assets', logoPathParts.dir, error);
+  }
+
+  return uniqueStrings(candidatePaths);
+}
+
+function getWindowsVisualElementsIconDataUrl(processPath: string | null): string | undefined {
+  for (const manifestPath of getWindowsVisualElementsManifestPaths(processPath)) {
+    if (!existsSync(manifestPath)) {
+      continue;
+    }
+
+    for (const logoPath of getWindowsManifestLogoPaths(manifestPath)) {
+      for (const candidatePath of getWindowsLogoCandidatePaths(manifestPath, logoPath)) {
+        const iconDataUrl = getIconDataUrlFromPath(candidatePath);
+        if (iconDataUrl) {
+          return iconDataUrl;
+        }
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function getPersonalAnalyticsIconDataUrl(): string | undefined {
@@ -50,10 +233,37 @@ function getIconDataUrlFromPath(iconPath: string | undefined): string | undefine
 
   const icon = nativeImage.createFromPath(iconPath);
   if (icon.isEmpty()) {
+    if (process.platform === 'darwin' && path.extname(iconPath).toLowerCase() === '.icns') {
+      return getMacIcnsDataUrlViaSips(iconPath);
+    }
+
     return undefined;
   }
 
   return icon.resize({ width: APP_ICON_SIZE, height: APP_ICON_SIZE }).toDataURL();
+}
+
+function getMacIcnsDataUrlViaSips(iconPath: string): string | undefined {
+  const tempDirectory = mkdtempSync(path.join(tmpdir(), 'personal-analytics-icon-'));
+  const pngPath = path.join(tempDirectory, 'icon.png');
+
+  try {
+    execFileSync('/usr/bin/sips', ['-s', 'format', 'png', '--out', pngPath, iconPath], {
+      stdio: 'ignore'
+    });
+
+    const icon = nativeImage.createFromBuffer(readFileSync(pngPath));
+    if (icon.isEmpty()) {
+      return undefined;
+    }
+
+    return icon.resize({ width: APP_ICON_SIZE, height: APP_ICON_SIZE }).toDataURL();
+  } catch (error) {
+    LOG.debug('Could not convert macOS icns app icon', iconPath, error);
+    return undefined;
+  } finally {
+    rmSync(tempDirectory, { recursive: true, force: true });
+  }
 }
 
 function getBundleResourceIconDataUrl(
@@ -149,6 +359,11 @@ export async function getProcessIconDataUrl(
 
     if (!processPath) {
       return undefined;
+    }
+
+    const windowsVisualElementsIcon = getWindowsVisualElementsIconDataUrl(processPath);
+    if (windowsVisualElementsIcon) {
+      return windowsVisualElementsIcon;
     }
 
     return app

--- a/src/electron/package-lock.json
+++ b/src/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "personal-analytics",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "personal-analytics",
-      "version": "0.0.57",
+      "version": "0.0.58",
       "hasInstallScript": true,
       "dependencies": {
         "archiver": "^7.0.1",
@@ -15,6 +15,7 @@
         "d3": "^7.9.0",
         "dompurify": "^3.3.2",
         "electron-log": "^5.1.1",
+        "extract-file-icon": "^0.3.2",
         "form-data": "^4.0.6",
         "jsdom": "^25.0.1",
         "node-schedule": "^2.1.1",
@@ -8119,6 +8120,22 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "devOptional": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/extract-file-icon": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extract-file-icon/-/extract-file-icon-0.3.2.tgz",
+      "integrity": "sha512-We5/HaMDlioOx3c9zDjit8RtKWEvT94sJF8jTujaKVOyWL8Kkqu4QGnwDr5fID6XsbKvWT0JJNuWuV2Tmr7yiw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "1.7.1"
+      }
+    },
+    "node_modules/extract-file-icon/node_modules/node-addon-api": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
+      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
+      "license": "MIT"
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",

--- a/src/electron/package.json
+++ b/src/electron/package.json
@@ -75,6 +75,7 @@
     "better-sqlite3-multiple-ciphers": "^9.4.0",
     "dompurify": "^3.3.2",
     "electron-log": "^5.1.1",
+    "extract-file-icon": "^0.3.2",
     "form-data": "^4.0.6",
     "jsdom": "^25.0.1",
     "node-schedule": "^2.1.1",

--- a/src/electron/patches/extract-file-icon+0.3.2.patch
+++ b/src/electron/patches/extract-file-icon+0.3.2.patch
@@ -1,0 +1,448 @@
+diff --git a/node_modules/extract-file-icon/binding.gyp b/node_modules/extract-file-icon/binding.gyp
+index 28bdfbc..ef8cbea 100644
+--- a/node_modules/extract-file-icon/binding.gyp
++++ b/node_modules/extract-file-icon/binding.gyp
+@@ -9,8 +9,13 @@
+           'link_settings': {
+             'libraries': [
+               'Gdiplus.lib',
++              'Shell32.lib',
+             ],
+           },
++          'defines': [
++            '_WIN32_WINNT=0x0603',
++            'WINVER=0x0603',
++          ],
+           'sources': [
+             'lib/addon.cc',
+           ],
+diff --git a/node_modules/extract-file-icon/dist/index.d.ts b/node_modules/extract-file-icon/dist/index.d.ts
+index 2df1855..bc6310b 100644
+--- a/node_modules/extract-file-icon/dist/index.d.ts
++++ b/node_modules/extract-file-icon/dist/index.d.ts
+@@ -1,3 +1,8 @@
+ /// <reference types="node" />
+-declare const getFileIcon: (path: string, size?: 16 | 32 | 64 | 256) => Buffer;
++type IconSize = 16 | 32 | 64 | 256;
++interface ExtractFileIcon {
++    (path: string, size?: IconSize): Buffer | undefined;
++    getPackageIcon(processId: number, path: string, size?: IconSize): Buffer | undefined;
++}
++declare const getFileIcon: ExtractFileIcon;
+ export = getFileIcon;
+diff --git a/node_modules/extract-file-icon/dist/index.js b/node_modules/extract-file-icon/dist/index.js
+index 886c2ad..2763652 100644
+--- a/node_modules/extract-file-icon/dist/index.js
++++ b/node_modules/extract-file-icon/dist/index.js
+@@ -1,13 +1,21 @@
+ "use strict";
+ const os_1 = require("os");
+ let getIcon;
++let getPackageIcon;
+ if (os_1.platform() === "win32" || os_1.platform() === 'darwin') {
+-    getIcon = require("../build/Release/addon.node").getIcon;
++    const addon = require("../build/Release/addon.node");
++    getIcon = addon.getIcon;
++    getPackageIcon = addon.getPackageIcon;
+ }
+ const getFileIcon = (path, size = 64) => {
+     if (!getIcon)
+         return;
+     return getIcon(path, size);
+ };
++getFileIcon.getPackageIcon = (processId, path, size = 64) => {
++    if (!getPackageIcon)
++        return;
++    return getPackageIcon(processId, path, size);
++};
+ module.exports = getFileIcon;
+ //# sourceMappingURL=index.js.map
+diff --git a/node_modules/extract-file-icon/lib/addon.cc b/node_modules/extract-file-icon/lib/addon.cc
+index 80f73c0..556060b 100644
+--- a/node_modules/extract-file-icon/lib/addon.cc
++++ b/node_modules/extract-file-icon/lib/addon.cc
+@@ -1,13 +1,18 @@
+ #include <Windows.h>
++#include <appmodel.h>
+ #include <Commctrl.h>
+ #include <CommonControls.h>
++#include <ShObjIdl.h>
+ #include <napi.h>
+ #include <algorithm>
+ #include <cstddef>
++#include <cstdint>
+ #include <cwchar>
++#include <cwctype>
+ #include <memory>
+-#include <vector>
++#include <string>
+ #include <system_error>
++#include <vector>
+ 
+ namespace Gdiplus {
+ using std::max;
+@@ -17,13 +22,19 @@ using std::min;
+ 
+ class ComInit {
+    public:
+-    ComInit() { CoInitializeEx(0, COINIT_MULTITHREADED); }
++    ComInit() : initialized(SUCCEEDED(CoInitializeEx(0, COINIT_MULTITHREADED))) {}
+ 
+-    ~ComInit() { CoUninitialize(); }
++    ~ComInit() {
++        if (initialized) {
++            CoUninitialize();
++        }
++    }
+ 
+    private:
+     ComInit(const ComInit &);
+     ComInit &operator=(const ComInit &);
++
++    bool initialized;
+ };
+ 
+ class GdiPlusInit {
+@@ -112,6 +123,52 @@ std::unique_ptr<Gdiplus::Bitmap> CreateBitmapFromIcon(
+     return bitmap;
+ }
+ 
++std::unique_ptr<Gdiplus::Bitmap> CreateBitmapFromHBitmap(
++    HBITMAP hBitmap, std::vector<std::int32_t> &buffer) {
++    BITMAP bm = {0};
++    if (hBitmap == nullptr || GetObject(hBitmap, sizeof(bm), std::addressof(bm)) == 0 ||
++        bm.bmWidth <= 0 || bm.bmHeight <= 0) {
++        return nullptr;
++    }
++
++    auto hDC = GetDC(nullptr);
++    if (hDC == nullptr) {
++        return nullptr;
++    }
++
++    BITMAPINFO bmi = {0};
++    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
++    bmi.bmiHeader.biWidth = bm.bmWidth;
++    bmi.bmiHeader.biHeight = -bm.bmHeight;
++    bmi.bmiHeader.biPlanes = 1;
++    bmi.bmiHeader.biBitCount = 32;
++    bmi.bmiHeader.biCompression = BI_RGB;
++
++    const auto pixelCount = static_cast<std::size_t>(bm.bmWidth) * bm.bmHeight;
++    buffer.resize(pixelCount);
++    const auto scanLines = GetDIBits(hDC, hBitmap, 0, bm.bmHeight, buffer.data(),
++                                     std::addressof(bmi), DIB_RGB_COLORS);
++    ReleaseDC(nullptr, hDC);
++
++    if (scanLines != bm.bmHeight) {
++        return nullptr;
++    }
++
++    const auto hasAlpha = std::any_of(
++        buffer.begin(), buffer.end(),
++        [](std::int32_t pixel) { return (pixel & 0xFF000000) != 0; });
++    if (!hasAlpha) {
++        for (auto &pixel : buffer) {
++            pixel |= 0xFF000000;
++        }
++    }
++
++    return std::unique_ptr<Gdiplus::Bitmap>(new Gdiplus::Bitmap(
++        bm.bmWidth, bm.bmHeight, bm.bmWidth * sizeof(std::int32_t),
++        PixelFormat32bppARGB,
++        static_cast<BYTE *>(static_cast<void *>(buffer.data()))));
++}
++
+ int GetEncoderClsid(const WCHAR *format, CLSID *pClsid) {
+     UINT num = 0u;
+     UINT size = 0u;
+@@ -142,11 +199,10 @@ int GetEncoderClsid(const WCHAR *format, CLSID *pClsid) {
+     return -1;
+ }
+ 
+-std::vector<unsigned char> HIconToPNG(HICON hIcon) {
+-    GdiPlusInit init;
+-
+-    std::vector<std::int32_t> buffer;
+-    auto bitmap = CreateBitmapFromIcon(hIcon, buffer);
++std::vector<unsigned char> BitmapToPNG(Gdiplus::Bitmap *bitmap) {
++    if (bitmap == nullptr || bitmap->GetLastStatus() != Gdiplus::Status::Ok) {
++        return std::vector<unsigned char>{};
++    }
+ 
+     CLSID encoder;
+     if (GetEncoderClsid(L"image/png", std::addressof(encoder)) == -1) {
+@@ -187,9 +243,29 @@ std::vector<unsigned char> HIconToPNG(HICON hIcon) {
+     return result;
+ }
+ 
++std::vector<unsigned char> HIconToPNG(HICON hIcon) {
++    GdiPlusInit init;
++
++    std::vector<std::int32_t> buffer;
++    auto bitmap = CreateBitmapFromIcon(hIcon, buffer);
++    return BitmapToPNG(bitmap.get());
++}
++
++std::vector<unsigned char> HBitmapToPNG(HBITMAP hBitmap) {
++    GdiPlusInit init;
++
++    std::vector<std::int32_t> buffer;
++    auto bitmap = CreateBitmapFromHBitmap(hBitmap, buffer);
++    return BitmapToPNG(bitmap.get());
++}
++
+ std::wstring Utf8ToWide(const std::string &src) {
+     const auto size =
+         MultiByteToWideChar(CP_UTF8, 0u, src.data(), -1, nullptr, 0u);
++    if (size == 0) {
++        return std::wstring{};
++    }
++
+     std::vector<wchar_t> dest(size, L'\0');
+ 
+     if (MultiByteToWideChar(CP_UTF8, 0u, src.data(), -1, dest.data(),
+@@ -198,7 +274,193 @@ std::wstring Utf8ToWide(const std::string &src) {
+                                 std::system_category()};
+     }
+ 
+-    return std::wstring{dest.begin(), dest.end()};
++    return std::wstring{dest.data()};
++}
++
++bool ProcessPathMatches(HANDLE process, const std::wstring &expectedPath) {
++    std::vector<wchar_t> processPath(MAX_PATH);
++
++    while (processPath.size() <= 32768) {
++        DWORD processPathLength = static_cast<DWORD>(processPath.size());
++        if (QueryFullProcessImageNameW(process, 0, processPath.data(),
++                                       std::addressof(processPathLength))) {
++            return _wcsicmp(processPath.data(), expectedPath.c_str()) == 0;
++        }
++
++        if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
++            return false;
++        }
++
++        processPath.resize(processPath.size() * 2);
++    }
++
++    return false;
++}
++
++std::wstring GetApplicationUserModelIdForProcess(
++    DWORD processId, const std::wstring &expectedPath) {
++    if (processId == 0 || expectedPath.empty()) {
++        return std::wstring{};
++    }
++
++    auto process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, processId);
++    if (process == nullptr) {
++        return std::wstring{};
++    }
++
++    std::wstring applicationUserModelId;
++    if (ProcessPathMatches(process, expectedPath)) {
++        UINT32 applicationUserModelIdLength = 0;
++        const auto firstResult = GetApplicationUserModelId(
++            process, std::addressof(applicationUserModelIdLength), nullptr);
++        if (firstResult == ERROR_INSUFFICIENT_BUFFER &&
++            applicationUserModelIdLength > 0) {
++            std::vector<wchar_t> buffer(applicationUserModelIdLength, L'\0');
++            if (GetApplicationUserModelId(process,
++                                          std::addressof(applicationUserModelIdLength),
++                                          buffer.data()) == ERROR_SUCCESS) {
++                applicationUserModelId = std::wstring(buffer.data());
++            }
++        }
++    }
++
++    CloseHandle(process);
++    return applicationUserModelId;
++}
++
++std::wstring GetWindowsAppsPackageFullName(const std::wstring &processPath) {
++    std::wstring normalizedPath(processPath);
++    std::replace(normalizedPath.begin(), normalizedPath.end(), L'/', L'\\');
++
++    const std::wstring windowsAppsMarker = L"\\windowsapps\\";
++    const auto markerPosition = std::search(
++        normalizedPath.begin(), normalizedPath.end(), windowsAppsMarker.begin(),
++        windowsAppsMarker.end(), [](wchar_t first, wchar_t second) {
++            return std::towlower(first) == std::towlower(second);
++        });
++    if (markerPosition == normalizedPath.end()) {
++        return std::wstring{};
++    }
++
++    const auto packageStart = static_cast<std::size_t>(
++        markerPosition - normalizedPath.begin() + windowsAppsMarker.size());
++    const auto packageEnd = normalizedPath.find(L'\\', packageStart);
++    if (packageEnd == packageStart) {
++        return std::wstring{};
++    }
++
++    return normalizedPath.substr(packageStart, packageEnd - packageStart);
++}
++
++std::vector<std::wstring> GetPackageApplicationUserModelIds(
++    const std::wstring &packageFullName) {
++    PACKAGE_INFO_REFERENCE packageInfoReference = nullptr;
++    if (OpenPackageInfoByFullName(packageFullName.c_str(), 0,
++                                  std::addressof(packageInfoReference)) != ERROR_SUCCESS) {
++        return std::vector<std::wstring>{};
++    }
++
++    UINT32 bufferLength = 0;
++    UINT32 applicationCount = 0;
++    const auto firstResult = GetPackageApplicationIds(
++        packageInfoReference, std::addressof(bufferLength), nullptr,
++        std::addressof(applicationCount));
++    if (firstResult != ERROR_INSUFFICIENT_BUFFER || bufferLength == 0 ||
++        applicationCount == 0) {
++        ClosePackageInfo(packageInfoReference);
++        return std::vector<std::wstring>{};
++    }
++
++    std::vector<BYTE> buffer(bufferLength);
++    const auto result = GetPackageApplicationIds(
++        packageInfoReference, std::addressof(bufferLength), buffer.data(),
++        std::addressof(applicationCount));
++    ClosePackageInfo(packageInfoReference);
++    if (result != ERROR_SUCCESS) {
++        return std::vector<std::wstring>{};
++    }
++
++    const auto applicationUserModelIds =
++        reinterpret_cast<PCWSTR *>(static_cast<void *>(buffer.data()));
++    std::vector<std::wstring> applicationIds;
++    applicationIds.reserve(applicationCount);
++    for (UINT32 index = 0; index < applicationCount; index++) {
++        if (applicationUserModelIds[index] != nullptr) {
++            applicationIds.emplace_back(applicationUserModelIds[index]);
++        }
++    }
++
++    return applicationIds;
++}
++
++std::vector<unsigned char> GetApplicationUserModelIcon(
++    const std::wstring &applicationUserModelId, int size) {
++    ComInit init;
++
++    const auto appsFolderPath =
++        std::wstring(L"shell:AppsFolder\\") + applicationUserModelId;
++    IShellItem *shellItem = nullptr;
++    if (FAILED(SHCreateItemFromParsingName(appsFolderPath.c_str(), nullptr,
++                                           IID_PPV_ARGS(std::addressof(shellItem))))) {
++        return std::vector<unsigned char>{};
++    }
++
++    IShellItemImageFactory *imageFactory = nullptr;
++    const auto interfaceResult =
++        shellItem->QueryInterface(IID_PPV_ARGS(std::addressof(imageFactory)));
++    shellItem->Release();
++    if (FAILED(interfaceResult)) {
++        return std::vector<unsigned char>{};
++    }
++
++    HBITMAP hBitmap = nullptr;
++    const SIZE iconSize = {size, size};
++    const auto imageResult = imageFactory->GetImage(
++        iconSize, static_cast<SIIGBF>(SIIGBF_ICONONLY | SIIGBF_BIGGERSIZEOK),
++        std::addressof(hBitmap));
++    imageFactory->Release();
++    if (FAILED(imageResult) || hBitmap == nullptr) {
++        return std::vector<unsigned char>{};
++    }
++
++    const auto icon = HBitmapToPNG(hBitmap);
++    DeleteObject(hBitmap);
++    return icon;
++}
++
++std::vector<unsigned char> GetWindowsAppsPackageIcon(
++    DWORD processId, const std::string &processPath, int size) {
++    const auto wideProcessPath = Utf8ToWide(processPath);
++    const auto packageFullName = GetWindowsAppsPackageFullName(wideProcessPath);
++    if (packageFullName.empty()) {
++        return std::vector<unsigned char>{};
++    }
++
++    const auto processApplicationUserModelId =
++        GetApplicationUserModelIdForProcess(processId, wideProcessPath);
++    if (!processApplicationUserModelId.empty()) {
++        const auto icon =
++            GetApplicationUserModelIcon(processApplicationUserModelId, size);
++        if (!icon.empty()) {
++            return icon;
++        }
++    }
++
++    for (const auto &applicationUserModelId :
++         GetPackageApplicationUserModelIds(packageFullName)) {
++        if (!processApplicationUserModelId.empty() &&
++            _wcsicmp(applicationUserModelId.c_str(),
++                      processApplicationUserModelId.c_str()) == 0) {
++            continue;
++        }
++
++        const auto icon = GetApplicationUserModelIcon(applicationUserModelId, size);
++        if (!icon.empty()) {
++            return icon;
++        }
++    }
++
++    return std::vector<unsigned char>{};
+ }
+ 
+ std::vector<unsigned char> GetIcon(const std::string &name, int size,
+@@ -255,21 +517,45 @@ std::vector<unsigned char> GetIcon(const std::string &name, int size,
+     return buffer;
+ }
+ 
++Napi::Buffer<char> CreateBuffer(Napi::Env env,
++                                const std::vector<unsigned char> &data) {
++    if (data.empty()) {
++        return Napi::Buffer<char>::New(env, 0);
++    }
++
++    return Napi::Buffer<char>::Copy(
++        env, reinterpret_cast<const char *>(data.data()), data.size());
++}
++
+ Napi::Buffer<char> getIcon(const Napi::CallbackInfo &info) {
+     Napi::Env env{info.Env()};
+ 
+     auto path{info[0].As<Napi::String>().Utf8Value()};
+     auto data = GetIcon(path, info[1].As<Napi::Number>().Int32Value(), 0);
+ 
+-    uint8_t *arr = &data[0];
++    return CreateBuffer(env, data);
++}
+ 
+-    return Napi::Buffer<char>::Copy(
+-        env, static_cast<char *>(static_cast<void *>(arr)), data.size());
++Napi::Buffer<char> getPackageIcon(const Napi::CallbackInfo &info) {
++    Napi::Env env{info.Env()};
++    if (info.Length() < 3 || !info[0].IsNumber() || !info[1].IsString() ||
++        !info[2].IsNumber()) {
++        return Napi::Buffer<char>::New(env, 0);
++    }
++
++    const auto processId = info[0].As<Napi::Number>().Uint32Value();
++    const auto processPath = info[1].As<Napi::String>().Utf8Value();
++    const auto size = info[2].As<Napi::Number>().Int32Value();
++    const auto data = GetWindowsAppsPackageIcon(processId, processPath, size);
++
++    return CreateBuffer(env, data);
+ }
+ 
+ Napi::Object Init(Napi::Env env, Napi::Object exports) {
+     exports.Set(Napi::String::New(env, "getIcon"),
+                 Napi::Function::New(env, getIcon));
++    exports.Set(Napi::String::New(env, "getPackageIcon"),
++                Napi::Function::New(env, getPackageIcon));
+ 
+     return exports;
+ }

--- a/src/electron/src/components/StackedBarChart.vue
+++ b/src/electron/src/components/StackedBarChart.vue
@@ -141,11 +141,11 @@ function getDetailInitial(detail: TimelineHoverDetail): string {
 
 function renderTooltipDetailIcon(detail: TimelineHoverDetail): string {
   if (detail.iconDataUrl) {
-    return `<img src="${escapeHtml(detail.iconDataUrl)}" alt="" style="width: 16px; height: 16px; border-radius: 4px; flex: 0 0 auto;" />`;
+    return `<img src="${escapeHtml(detail.iconDataUrl)}" alt="" style="width: 28px; height: 28px; flex: 0 0 auto; object-fit: contain;" />`;
   }
 
   return `
-    <span style="width: 16px; height: 16px; border-radius: 4px; flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; background: rgba(148, 163, 184, 0.22); color: #64748b; font-size: 10px; font-weight: 700;">
+    <span style="width: 28px; height: 28px; border-radius: 6px; flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; background: rgba(148, 163, 184, 0.22); color: #64748b; font-size: 13px; font-weight: 700;">
       ${escapeHtml(getDetailInitial(detail))}
     </span>
   `;
@@ -176,7 +176,7 @@ function renderTooltipDetail(detail: TimelineHoverDetail): string {
 
   return `
     <li title="${tooltipTitle}" style="display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 10px; align-items: center;">
-      <span style="min-width: 0; display: inline-flex; align-items: center; gap: 6px;">
+      <span style="min-width: 0; display: inline-flex; align-items: center; gap: 8px;">
         ${renderTooltipDetailIcon(detail)}
         <span style="min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
           ${title}${appLabel ? `<span style="color: #94a3b8;"> &middot; </span>${appLabel}` : ''}

--- a/src/electron/src/components/StackedBarChart.vue
+++ b/src/electron/src/components/StackedBarChart.vue
@@ -141,11 +141,11 @@ function getDetailInitial(detail: TimelineHoverDetail): string {
 
 function renderTooltipDetailIcon(detail: TimelineHoverDetail): string {
   if (detail.iconDataUrl) {
-    return `<img src="${escapeHtml(detail.iconDataUrl)}" alt="" style="width: 28px; height: 28px; flex: 0 0 auto; object-fit: contain;" />`;
+    return `<img src="${escapeHtml(detail.iconDataUrl)}" alt="" style="width: 16px; height: 16px; border-radius: 4px; flex: 0 0 auto;" />`;
   }
 
   return `
-    <span style="width: 28px; height: 28px; border-radius: 6px; flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; background: rgba(148, 163, 184, 0.22); color: #64748b; font-size: 13px; font-weight: 700;">
+    <span style="width: 16px; height: 16px; border-radius: 4px; flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; background: rgba(148, 163, 184, 0.22); color: #64748b; font-size: 10px; font-weight: 700;">
       ${escapeHtml(getDetailInitial(detail))}
     </span>
   `;
@@ -176,7 +176,7 @@ function renderTooltipDetail(detail: TimelineHoverDetail): string {
 
   return `
     <li title="${tooltipTitle}" style="display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 10px; align-items: center;">
-      <span style="min-width: 0; display: inline-flex; align-items: center; gap: 8px;">
+      <span style="min-width: 0; display: inline-flex; align-items: center; gap: 6px;">
         ${renderTooltipDetailIcon(detail)}
         <span style="min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
           ${title}${appLabel ? `<span style="color: #94a3b8;"> &middot; </span>${appLabel}` : ''}


### PR DESCRIPTION
# Retrospection: Fix Timeline Detail App Icons (Closes #552)

## Description

Fixes missing or generic app icons in Retrospection timeline details, especially for Microsoft Office apps. Office icons can fail through Electron’s default icon lookup on both Windows and macOS, so icon resolution now includes platform-specific fallbacks before falling back to Electron’s shell icon API.

### Changes Made

- Resolves Windows Office icons from sibling `*.VisualElementsManifest.xml` files when available
- Supports Windows visual asset variants such as `targetsize-64`, `targetsize-32`, and scaled logo files
- Handles macOS `.icns` files that Electron cannot load directly by converting them to PNG with `sips`
- Uses the app bundle’s declared `CFBundleIconFile` before generic bundle resource scanning
- Increases the icon backing image size so modern Office icons retain detail
- Increases Retrospection timeline detail icon display size for better recognizability
- Adds focused tests for Windows manifest icon resolution
- Adds focused tests for Electron shell icon fallback
- Adds focused tests for macOS `.icns` conversion fallback

Closes #552