### PR TITLE
[#547] Retrospection: Fix URL-Like Window Titles with Colons

### DIFF
--- a/src/electron/electron/main/__tests__/RetrospectionService.test.ts
+++ b/src/electron/electron/main/__tests__/RetrospectionService.test.ts
@@ -61,6 +61,16 @@ const cases: [string, string | boolean | null, string | boolean | null][] = [
     'github.com/pull/123'
   ],
   [
+    'browser page titles with colon after a domain-like brand are not treated as URLs',
+    cleanWindowTitle('Levels.fyi: Overview', 'Microsoft Edge'),
+    'Levels.fyi: Overview'
+  ],
+  [
+    'browser product titles with colon after a domain-like brand are not treated as URLs',
+    cleanWindowTitle('Amazon.ca: Product Name', 'Microsoft Edge'),
+    'Amazon.ca: Product Name'
+  ],
+  [
     'hover URL-only window titles include ellipsis when shortened',
     cleanWindowTitle(
       'github.com/HASEL-UZH/PersonalAnalytics/pull/123',

--- a/src/electron/electron/main/services/RetrospectionService.ts
+++ b/src/electron/electron/main/services/RetrospectionService.ts
@@ -491,7 +491,7 @@ export function removeGenericBrowserTabCountFragments(title: string): string {
  * original path was shortened.
  */
 export function getReadableUrlTitle(title: string, includeEllipsis = false): string | null {
-  if (!/^[\w.-]+\.[a-z]{2,}(?:[/:?#]|$)/i.test(title)) {
+  if (!/^[\w.-]+\.[a-z]{2,}(?:\/|[?#]|:\d|$)/i.test(title)) {
     return null;
   }
 


### PR DESCRIPTION
# Retrospection: Fix URL-Like Window Titles with Colons (Closes #547)

## Description

Fixes a Retrospection crash/log warning when cleaning browser window titles that look partially like domains but are actually normal page titles.

Examples:

- `Levels.fyi: Overview`
- `Amazon.ca: Product Name`

Previously, these titles were detected as URL-like because the URL pre-check allowed any colon after a domain-looking prefix. The cleaner then passed values like `https://Levels.fyi: Overview` to `new URL(...)`, which threw because a colon after a hostname is parsed as a port separator.

### Changes Made

- Tightened the URL-like title detection in `getReadableUrlTitle`
- Only treats `:` after a domain as URL syntax when it starts a numeric port, such as `example.com:8080`
- Keeps normal title-style colons unchanged, such as `Levels.fyi: Overview`
- Preserves existing handling for real URL-like titles using `/`, `?`, `#`, or no suffix after the domain
- Added regression tests for `Levels.fyi: Overview`
- Added regression tests for `Amazon.ca: Product Name`

Closes #547