### PR TITLE
[#365] Fix tray updater menu item and tray click listener leak

### DIFF
--- a/src/electron/electron/main/services/WindowService.ts
+++ b/src/electron/electron/main/services/WindowService.ts
@@ -480,11 +480,13 @@ export class WindowService {
     if (!this.tray) return
     LOG.debug('Updating tray')
     const menuTemplate: MenuItemConstructorOptions[] = await this.getTrayMenuTemplate()
-    menuTemplate[1].label = updaterLabel
-    menuTemplate[1].enabled = updaterMenuEnabled
+    const updaterMenuItem = menuTemplate.find((item) => item.id === 'check-for-updates')
+    if (updaterMenuItem) {
+      updaterMenuItem.label = updaterLabel
+      updaterMenuItem.enabled = updaterMenuEnabled
+    }
 
     this.tray.setContextMenu(Menu.buildFromTemplate(menuTemplate))
-    this.tray.on("click", () => { this.tray?.popUpContextMenu() })
     this.tray.setToolTip(`${is.dev ? '[DEV MODE] ' : ''}Personal Analytics is running...\n\nYou are participating in: ${studyConfig.name}`)
   }
 
@@ -498,6 +500,7 @@ export class WindowService {
     const trayImage = nativeImage.createFromPath(appIcon)
     trayImage.setTemplateImage(true)
     this.tray = new Tray(trayImage)
+    this.tray.on('click', () => this.tray?.popUpContextMenu())
     await this.updateTray()
   }
 
@@ -512,10 +515,12 @@ export class WindowService {
       (!allowDisable || (settings?.userDisabledExperienceSampling ?? 0) === 0);
     
     const trayMenuItems: MenuItemConstructorOptions[] = [
-      { label: '⚠ DEV MODE', enabled: false, visible: is.dev },
-      { type: 'separator', visible: is.dev },
+      ...(is.dev
+        ? [{ label: '⚠ DEV MODE', enabled: false }, { type: 'separator' as const }]
+        : []),
       { label: `Version ${app.getVersion()}`, enabled: false },
       {
+        id: 'check-for-updates',
         label: 'Check for updates',
         enabled: false,
         click: () => this.appUpdaterService.checkForUpdates({ silent: false })


### PR DESCRIPTION
The tray menu addressed the updater item by index (`menuTemplate[1]`), but adding the dev-only "DEV MODE" label and separator shifted that index by two — so updater refreshes wrote onto the dev separator (drawing it as a stray line above "Version x.y.z" in production) while "Check for updates" stayed permanently disabled. Now looked up by `id`, with the dev-only entries built conditionally. Also moves the tray `click` handler from `updateTray()` (which re-registered it on every updater check and settings change, leaking listeners) to `createTray()`.

`vue-tsc --noEmit` passes; not yet exercised in a packaged build.

Refs #365