### PR TITLE
 [#555] Fix retrospection visualization data

### DIFF
--- a/src/electron/electron/main/__tests__/ExperienceSamplingService.test.ts
+++ b/src/electron/electron/main/__tests__/ExperienceSamplingService.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, expect, jest, test } from '@jest/globals';
+
+const where = jest.fn();
+const andWhere = jest.fn();
+const orderBy = jest.fn();
+const getMany = jest.fn();
+const createQueryBuilder = jest.fn();
+
+jest.unstable_mockModule('electron', () => ({
+  default: {
+    app: {
+      isPackaged: false
+    }
+  }
+}));
+
+jest.unstable_mockModule('../entities/ExperienceSamplingResponseEntity', () => ({
+  ExperienceSamplingResponseEntity: {
+    createQueryBuilder
+  }
+}));
+
+const { ExperienceSamplingService } = await import('../services/ExperienceSamplingService');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getMany.mockResolvedValue([] as never);
+  orderBy.mockReturnValue({ getMany });
+  andWhere.mockReturnValue({ orderBy });
+  where.mockReturnValue({ andWhere });
+  createQueryBuilder.mockReturnValue({ where });
+});
+
+test('self-reports are queried using the selected 04:00-to-04:00 local workday', async () => {
+  const service = new ExperienceSamplingService();
+
+  await service.getExperienceSamplingDtosForDay(new Date(2026, 5, 29, 0, 0));
+
+  expect(createQueryBuilder).toHaveBeenCalledWith('experienceSampling');
+  expect(where).toHaveBeenCalledWith(
+    "datetime(experienceSampling.promptedAt, 'localtime') >= :workdayStart",
+    { workdayStart: '2026-06-29 04:00:00' }
+  );
+  expect(andWhere).toHaveBeenCalledWith(
+    "datetime(experienceSampling.promptedAt, 'localtime') < :workdayEnd",
+    { workdayEnd: '2026-06-30 04:00:00' }
+  );
+});
+
+test('date-only self-report queries do not pass through UTC date conversion', async () => {
+  const service = new ExperienceSamplingService();
+
+  await service.getExperienceSamplingDtosForDay('2026-06-29');
+
+  expect(where).toHaveBeenCalledWith(expect.any(String), {
+    workdayStart: '2026-06-29 04:00:00'
+  });
+  expect(andWhere).toHaveBeenCalledWith(expect.any(String), {
+    workdayEnd: '2026-06-30 04:00:00'
+  });
+});

--- a/src/electron/electron/main/services/ExperienceSamplingService.ts
+++ b/src/electron/electron/main/services/ExperienceSamplingService.ts
@@ -3,6 +3,10 @@ import getMainLogger from '../../config/Logger';
 import ExperienceSamplingDto from '../../../shared/dto/ExperienceSamplingDto';
 import type { ExperienceSamplingResponseInput } from '../../../shared/dto/ExperienceSamplingDto';
 import type { ExperienceSamplingAnswerType } from '../../../shared/StudyConfiguration';
+import {
+  formatSqliteLocalDateTime,
+  getRetrospectionWorkdayRange
+} from '../../../shared/retrospection/Workday';
 
 const LOG = getMainLogger('ExperienceSamplingService');
 
@@ -85,12 +89,18 @@ export class ExperienceSamplingService {
   public async getExperienceSamplingDtosForDay(
     date: Date | string
   ): Promise<ExperienceSamplingDto[]> {
-    const d = typeof date === 'string' ? new Date(date) : date;
-    const daystr = d.toISOString().split('T')[0];
+    const workdayRange = getRetrospectionWorkdayRange(date);
+    const workdayStart = formatSqliteLocalDateTime(workdayRange.start);
+    const workdayEnd = formatSqliteLocalDateTime(workdayRange.end);
     const experienceSamplingResponses = await ExperienceSamplingResponseEntity.createQueryBuilder(
       'experienceSampling'
     )
-      .where("date(experienceSampling.promptedAt, 'localtime') = :daystr", { daystr })
+      .where("datetime(experienceSampling.promptedAt, 'localtime') >= :workdayStart", {
+        workdayStart
+      })
+      .andWhere("datetime(experienceSampling.promptedAt, 'localtime') < :workdayEnd", {
+        workdayEnd
+      })
       .orderBy('experienceSampling.promptedAt', 'ASC')
       .getMany();
 

--- a/src/electron/electron/main/services/RetrospectionService.ts
+++ b/src/electron/electron/main/services/RetrospectionService.ts
@@ -3,7 +3,15 @@ import { WindowActivityEntity } from '../entities/WindowActivityEntity';
 import { getMainLogger } from '../../config/Logger';
 import { Activity, type ActiveHoursInsight } from '../../../src/utils/retrospection/types';
 import { getProcessIconDataUrl } from './utils/AppIconHelper';
-import { formatSqliteLocalDateTime, getOverlapDurationMs } from './utils/helpers';
+import { getOverlapDurationMs } from './utils/helpers';
+import {
+  formatSqliteLocalDateTime,
+  getDateFromWorkdayMinuteIndex,
+  getRetrospectionWorkdayRange,
+  getWorkdayMinuteIndex
+} from '../../../shared/retrospection/Workday';
+
+export { getRetrospectionWorkdayRange, getWorkdayMinuteIndex };
 
 const LOG = getMainLogger('RetrospectionService');
 
@@ -46,7 +54,6 @@ interface WindowActivityDetailSpan {
 
 const TIMELINE_HOVER_DETAIL_LIMIT = 4;
 const MIN_TIMELINE_HOVER_DETAIL_DURATION_MS = 60_000;
-const WORKDAY_CUTOFF_HOUR = 4;
 
 // Mirrored from PA.WindowsActivityTracker/typescript/src/mappings/browsers.ts.
 // Used here to recognize browser processes without importing tracker source into the main bundle.
@@ -147,33 +154,6 @@ export function isBrowserProcessName(processName: string | null): boolean {
   );
 }
 
-/**
- * Returns the retrospection workday range for the selected calendar day.
- *
- * A workday starts at 04:00 local time and ends at 04:00 the next local day, so late-night work
- * before 04:00 is attributed to the previous workday.
- */
-export function getRetrospectionWorkdayRange(date: Date | string): { start: Date; end: Date } {
-  const d = typeof date === 'string' ? new Date(date) : date;
-  const start = new Date(d.getFullYear(), d.getMonth(), d.getDate(), WORKDAY_CUTOFF_HOUR, 0, 0, 0);
-  const end = new Date(start);
-  end.setDate(end.getDate() + 1);
-  return { start, end };
-}
-
-/**
- * Converts a timestamp to a minute offset in the 04:00-to-04:00 workday.
- */
-export function getWorkdayMinuteIndex(date: Date, workdayStart: Date): number {
-  return Math.floor((date.getTime() - workdayStart.getTime()) / 60000);
-}
-
-/**
- * Constructs a date object from a minute offset in the 04:00-to-04:00 workday.
- */
-function getDateFromWorkdayMinuteIndex(minuteIndex: number, workdayStart: Date): Date {
-  return new Date(workdayStart.getTime() + minuteIndex * 60000);
-}
 
 /**
  * finds and returns all minutes of the workday (0-1439) where user input was detected
@@ -1026,6 +1006,7 @@ export async function getActivitySessions(
           'Design',
           'GenerativeAI',
           'PlannedMeeting',
+          'InformalMeeting',
           'Email',
           'InstantMessaging',
           'WorkRelatedBrowsing',

--- a/src/electron/shared/retrospection/Workday.ts
+++ b/src/electron/shared/retrospection/Workday.ts
@@ -1,0 +1,89 @@
+export const RETROSPECTION_WORKDAY_CUTOFF_HOUR = 4;
+
+export interface RetrospectionWorkdayRange {
+  start: Date;
+  end: Date;
+}
+
+export interface RetrospectionTimelineBounds {
+  start: number;
+  end: number;
+}
+
+function toLocalDate(date: Date | string): Date {
+  if (date instanceof Date) return date;
+  const parts = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  return parts
+    ? new Date(Number(parts[1]), Number(parts[2]) - 1, Number(parts[3]))
+    : new Date(date);
+}
+
+/** Returns the selected local calendar day's 04:00-to-04:00 workday. */
+export function getRetrospectionWorkdayRange(date: Date | string): RetrospectionWorkdayRange {
+  const d = toLocalDate(date);
+  const start = new Date(
+    d.getFullYear(),
+    d.getMonth(),
+    d.getDate(),
+    RETROSPECTION_WORKDAY_CUTOFF_HOUR,
+    0,
+    0,
+    0
+  );
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return { start, end };
+}
+
+export function getWorkdayMinuteIndex(date: Date, workdayStart: Date): number {
+  return Math.floor((date.getTime() - workdayStart.getTime()) / 60000);
+}
+
+export function getDateFromWorkdayMinuteIndex(minuteIndex: number, workdayStart: Date): Date {
+  return new Date(workdayStart.getTime() + minuteIndex * 60000);
+}
+
+/** Formats a local timestamp for SQLite `datetime(..., 'localtime')` comparison. */
+export function formatSqliteLocalDateTime(date: Date): string {
+  const parts = [
+    date.getFullYear(),
+    `${date.getMonth() + 1}`.padStart(2, '0'),
+    `${date.getDate()}`.padStart(2, '0')
+  ];
+  const time = [date.getHours(), date.getMinutes(), date.getSeconds()]
+    .map((value) => `${value}`.padStart(2, '0'))
+    .join(':');
+  return `${parts.join('-')} ${time}`;
+}
+
+function floorToLocalHour(timestamp: number): number {
+  const date = new Date(timestamp);
+  date.setMinutes(0, 0, 0);
+  return date.getTime();
+}
+
+/** Computes one hour-aligned x-axis domain for every retrospection timeline. */
+export function getRetrospectionTimelineBounds(
+  selectedDay: Date | string,
+  timestamps: Array<Date | number | string | null | undefined>
+): RetrospectionTimelineBounds | null {
+  const values = timestamps
+    .map((timestamp) =>
+      timestamp instanceof Date
+        ? timestamp.getTime()
+        : typeof timestamp === 'string'
+          ? new Date(timestamp).getTime()
+          : timestamp
+    )
+    .filter((timestamp): timestamp is number => typeof timestamp === 'number' && Number.isFinite(timestamp));
+  const { start: workdayStartDate, end: workdayEndDate } = getRetrospectionWorkdayRange(selectedDay);
+  const workdayStart = workdayStartDate.getTime();
+  const workdayEnd = workdayEndDate.getTime();
+  const inRange = values.filter((timestamp) => timestamp >= workdayStart && timestamp < workdayEnd);
+  if (!inRange.length) return null;
+
+  const start = Math.max(floorToLocalHour(Math.min(...inRange)), workdayStart);
+  let end = Math.min(floorToLocalHour(Math.max(...inRange)) + 60 * 60 * 1000, workdayEnd);
+  if (end <= start) end = Math.min(start + 60 * 60 * 1000, workdayEnd);
+  return { start, end };
+}

--- a/src/electron/src/views/RetrospectionView.vue
+++ b/src/electron/src/views/RetrospectionView.vue
@@ -20,6 +20,7 @@ import StackedBarChart from '../components/StackedBarChart.vue';
 import SelfReportTimelineChart from '../components/SelfReportTimelineChart.vue';
 import type ExperienceSamplingDto from '../../shared/dto/ExperienceSamplingDto';
 import studyConfig from '../../shared/study.config';
+import { getRetrospectionTimelineBounds } from '../../shared/retrospection/Workday';
 
 const typedIpcRenderer = window.ipcRenderer;
 const isLoading = ref(false);
@@ -106,6 +107,11 @@ const latestSelfReport = computed((): number => {
 });
 
 const timelineStartDate = computed((): number => {
+  const bounds = getRetrospectionTimelineBounds(selectedDay.value, [
+    ...(chartDataWindowActivities.value ?? []).flatMap((point) => [point.start, point.end]),
+    ...selfReports.value.map((report) => report.promptedAt)
+  ]);
+  if (bounds) return bounds.start;
   const candidates = [
     hasActivityData.value ? earliestUserComputerActivity.value : null,
     hasLikertSelfReports.value ? earliestSelfReport.value : null
@@ -114,6 +120,11 @@ const timelineStartDate = computed((): number => {
 });
 
 const timelineEndDate = computed((): number => {
+  const bounds = getRetrospectionTimelineBounds(selectedDay.value, [
+    ...(chartDataWindowActivities.value ?? []).flatMap((point) => [point.start, point.end]),
+    ...selfReports.value.map((report) => report.promptedAt)
+  ]);
+  if (bounds) return bounds.end;
   const candidates = [
     hasActivityData.value ? latestUserComputerActivity.value : null,
     hasLikertSelfReports.value ? latestSelfReport.value : null
@@ -122,11 +133,11 @@ const timelineEndDate = computed((): number => {
 });
 
 const selfReportTimelineStartDate = computed((): number => {
-  return hasActivityData.value ? earliestUserComputerActivity.value : timelineStartDate.value;
+  return timelineStartDate.value;
 });
 
 const selfReportTimelineEndDate = computed((): number => {
-  return hasActivityData.value ? latestUserComputerActivity.value : timelineEndDate.value;
+  return timelineEndDate.value;
 });
 
 // Total tracked activity time is the denominator for percentages and the 90% cutoff.
@@ -226,14 +237,17 @@ onMounted(async () => {
 
 async function loadData() {
   isLoading.value = true;
-  await loadActiveHours();
-  await loadLongestTimeActive();
-  await loadMostActiveApps();
-  await loadTopWebsites();
-  await loadTopWindowTitles();
-  await loadSelfReports();
-  await loadWindowActivities();
-  isLoading.value = false;
+  try {
+    await loadActiveHours();
+    await loadLongestTimeActive();
+    await loadMostActiveApps();
+    await loadTopWebsites();
+    await loadTopWindowTitles();
+    await loadSelfReports();
+    await loadWindowActivities();
+  } finally {
+    isLoading.value = false;
+  }
 }
 
 function windowActivitiesToChartData() {
@@ -257,11 +271,17 @@ function windowActivitiesToChartData() {
 }
 
 async function loadWindowActivities() {
-  allWindowActivities.value = (await typedIpcRenderer.invoke(
-    'retrospectionGetActivities',
-    selectedDay.value
-  )) as ActivitySessions[];
-  windowActivitiesToChartData();
+  try {
+    allWindowActivities.value = (await typedIpcRenderer.invoke(
+      'retrospectionGetActivities',
+      selectedDay.value
+    )) as ActivitySessions[];
+    windowActivitiesToChartData();
+  } catch (error) {
+    console.error('Error loading window activities', error);
+    allWindowActivities.value = [];
+    chartDataWindowActivities.value = [];
+  }
 }
 
 async function loadActiveHours() {


### PR DESCRIPTION
# Retrospection visualization data fixes (Closes #555)

## Description

Fixes workday-boundary inconsistencies, missing informal meetings, timeline clipping, and loading failure handling in retrospection.

### Changes Made

- Resolve self-reports using the shared 04:00–04:00 retrospection workday range.
- Add shared workday and timeline-bound helpers.
- Include `InformalMeeting` in the Meeting timeline, legend, and activity breakdown.
- Use shared activity/self-report timeline bounds so valid self-report points are not clipped.
- Ensure failed activity loading clears the loading state and presents an empty state safely.
- Add workday and self-report loading regression coverage.

## Testing

- 50 targeted retrospection tests passed.
- `vue-tsc --noEmit` passed.
- Production build passed.