### PR TITLE
[#527] Make retrospection charts and layout responsive

### DIFF
--- a/src/electron/electron/main/services/WindowService.ts
+++ b/src/electron/electron/main/services/WindowService.ts
@@ -339,10 +339,10 @@ export class WindowService {
     const preload = join(__dirname, '../preload/index.mjs')
 
     this.retrospectionWindow = new BrowserWindow({
-      width: 850,
-      height: 800,
+      width: 1120,
+      height: 850,
       minWidth: 800,
-      minHeight: 750,
+      minHeight: 720,
       show: false,
       minimizable: false,
       maximizable: false,

--- a/src/electron/src/components/RetrospectionTopItemsCard.vue
+++ b/src/electron/src/components/RetrospectionTopItemsCard.vue
@@ -169,12 +169,17 @@ h2.primary-blue {
   border-radius: inherit;
 }
 
-:global(.dark) .top-item-track {
-  background: #111111;
-}
+@media (prefers-color-scheme: dark) {
+  .top-item-track {
+    background: #111111;
+  }
 
-:global(.dark) .top-item-label,
-:global(.dark) .top-item-time {
-  color: #ffffff;
+  .top-item-label {
+    color: #e2e8f0;
+  }
+
+  .top-item-time {
+    color: #cbd5e1;
+  }
 }
 </style>

--- a/src/electron/src/components/SelfReportTimelineChart.vue
+++ b/src/electron/src/components/SelfReportTimelineChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="self-report-chart">
+  <div ref="chartContainer" class="self-report-chart">
     <div
       ref="tooltip"
       class="self-report-tooltip rounded border border-gray-200 bg-white p-2 text-gray-700 opacity-0 shadow-lg transition-opacity duration-300 ease-in-out dark:border-transparent dark:bg-neutral-800 dark:text-neutral-300 dark:shadow-neutral-800/80"
@@ -67,13 +67,15 @@ const props = defineProps({
   }
 });
 
-const svgWidth = 760;
+const svgWidth = ref(760);
 const svgHeight = 190;
+const chartContainer = ref<HTMLElement | null>(null);
 const chart = ref<SVGElement | null>(null);
 const tooltip = ref<HTMLElement | null>(null);
 const darkMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 const isDark = ref(darkMediaQuery.matches);
 const selectedQuestion = ref<string | null>(null);
+let resizeObserver: ResizeObserver | undefined;
 
 const palette = [
   Color['blue-600'],
@@ -141,11 +143,23 @@ watch([() => props.startDate, () => props.endDate, series], () => {
 
 onMounted(() => {
   darkMediaQuery.addEventListener('change', onThemeChange);
+  updateChartWidth();
+  resizeObserver = new ResizeObserver(() => {
+    const previousWidth = svgWidth.value;
+    updateChartWidth();
+    if (svgWidth.value !== previousWidth) {
+      rebuildChart();
+    }
+  });
+  if (chartContainer.value) {
+    resizeObserver.observe(chartContainer.value);
+  }
   rebuildChart();
 });
 
 onUnmounted(() => {
   darkMediaQuery.removeEventListener('change', onThemeChange);
+  resizeObserver?.disconnect();
 });
 
 function onThemeChange(e: MediaQueryListEvent) {
@@ -261,13 +275,20 @@ function rebuildChart() {
   buildChart();
 }
 
+function updateChartWidth(): void {
+  const width = Math.floor(chartContainer.value?.getBoundingClientRect().width ?? 0);
+  if (width > 0) {
+    svgWidth.value = width;
+  }
+}
+
 function buildChart() {
   if (!chart.value) {
     return;
   }
 
   const margin = { top: 22, right: 0, bottom: 34, left: 0 };
-  const width = svgWidth - margin.left - margin.right;
+  const width = svgWidth.value - margin.left - margin.right;
   const height = svgHeight - margin.top - margin.bottom;
   const axisColor = isDark.value ? '#a3a3a3' : '#374151';
   const gridColor = isDark.value ? '#404040' : '#e5e7eb';
@@ -349,13 +370,22 @@ function buildChart() {
       );
   });
 
-  svg
+  const axisLabels = svg
     .append('g')
     .attr('class', 'x axis')
     .attr('transform', `translate(0, ${height})`)
     .call(d3.axisBottom(x).tickFormat(formatTimeTick))
     .selectAll('text')
     .style('fill', axisColor);
+
+  const labels = axisLabels.nodes();
+  labels.forEach((label, index) => {
+    if (index === 0) {
+      d3.select(label).attr('text-anchor', 'start').attr('x', 4);
+    } else if (index === labels.length - 1) {
+      d3.select(label).attr('text-anchor', 'end').attr('x', -4);
+    }
+  });
 
   svg.selectAll('.x.axis path, .x.axis line').style('stroke', axisColor);
 }
@@ -401,7 +431,12 @@ function getTooltipScaleSuffix(point: SelfReportPoint): string {
 <style scoped>
 .self-report-chart {
   position: relative;
-  width: 760px;
+  width: 100%;
+  min-width: 0;
+}
+
+.self-report-chart svg {
+  display: block;
   max-width: 100%;
 }
 

--- a/src/electron/src/components/StackedBarChart.vue
+++ b/src/electron/src/components/StackedBarChart.vue
@@ -1,15 +1,17 @@
 <template>
-  <div
-    id="tooltip"
-    class="rounded border border-gray-200 bg-white p-2 text-gray-700 opacity-0 shadow-lg transition-opacity duration-300 ease-in-out dark:border-transparent dark:bg-neutral-800 dark:text-neutral-300 dark:shadow-neutral-800/80"
-  >
-    <span id="content"></span>
+  <div ref="chartContainer" class="stacked-bar-chart">
+    <div
+      id="tooltip"
+      class="rounded border border-gray-200 bg-white p-2 text-gray-700 opacity-0 shadow-lg transition-opacity duration-300 ease-in-out dark:border-transparent dark:bg-neutral-800 dark:text-neutral-300 dark:shadow-neutral-800/80"
+    >
+      <span id="content"></span>
+    </div>
+    <svg ref="chart" :width="svgWidth" :height="svgHeight"></svg>
   </div>
-  <svg ref="chart" :width="svgWidth" :height="svgHeight"></svg>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, computed, watch } from 'vue';
+import { ref, onMounted, onUnmounted, watch, type PropType } from 'vue';
 import * as d3 from 'd3';
 import { Color } from '../utils/retrospection/types';
 import {
@@ -29,7 +31,7 @@ import {
 
 const props = defineProps({
   data: {
-    type: Array,
+    type: Array as PropType<ChartDataPoint[]>,
     required: true
   },
   type: {
@@ -49,53 +51,60 @@ const props = defineProps({
   }
 });
 
-const svgWidth = 760;
+const svgWidth = ref(760);
+const svgHeight = ref(135);
+const chartContainer = ref<HTMLElement | null>(null);
 const chart = ref<SVGElement | null>();
 const chartSelectedLegendItem = ref<string | null>();
 const darkMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 const isDark = ref(darkMediaQuery.matches);
+let resizeObserver: ResizeObserver | undefined;
 
 function onThemeChange(e: MediaQueryListEvent) {
   isDark.value = e.matches;
-  d3.select(chart.value!).selectAll('*').remove();
-  buildChart();
+  rebuildChart();
 }
-
-const chartStartDate = ref<number>();
-const chartEndDate = ref<number>();
 
 onMounted(() => {
   darkMediaQuery.addEventListener('change', onThemeChange);
-  const minStartTime = new Date(props.startDate).setHours(0, 0, 0, 0);
-  const maxEndTime = new Date(props.endDate).setHours(23, 59, 59, 999);
-  if (props.startDate > minStartTime) {
-    chartStartDate.value = props.startDate;
-  } else {
-    chartStartDate.value = minStartTime;
+  updateChartWidth();
+  resizeObserver = new ResizeObserver(() => {
+    const previousWidth = svgWidth.value;
+    updateChartWidth();
+    if (svgWidth.value !== previousWidth) {
+      rebuildChart();
+    }
+  });
+  if (chartContainer.value) {
+    resizeObserver.observe(chartContainer.value);
   }
-  if (props.endDate <= maxEndTime) {
-    chartEndDate.value = props.endDate;
-  } else {
-    chartEndDate.value = maxEndTime;
-  }
-  buildChart();
+  rebuildChart();
 });
 
 onUnmounted(() => {
   darkMediaQuery.removeEventListener('change', onThemeChange);
+  resizeObserver?.disconnect();
 });
 
-const svgHeight = computed(() => {
-  if (props.type === 'WINDOW_ACTIVITY') {
-    return 135;
-  } else {
-    return 100;
+watch([() => props.data, () => props.startDate, () => props.endDate], rebuildChart);
+
+function rebuildChart() {
+  if (!chart.value) {
+    return;
   }
-});
+  chartSelectedLegendItem.value = null;
+  svgHeight.value = props.type === 'WINDOW_ACTIVITY' ? 135 : 100;
+  d3.select('#tooltip').style('opacity', '0');
+  d3.select(chart.value).selectAll('*').remove();
+  buildChart();
+}
 
-watch([() => props.data], () => {
-  rebuildChartWithAnimation();
-});
+function updateChartWidth(): void {
+  const width = Math.floor(chartContainer.value?.getBoundingClientRect().width ?? 0);
+  if (width > 0) {
+    svgWidth.value = width;
+  }
+}
 
 function getActiveTaskTotalTimeSpentPerActivityGroupArray() {
   const activeTaskTotalTimeSpentPerActivityGroup: {
@@ -104,9 +113,9 @@ function getActiveTaskTotalTimeSpentPerActivityGroupArray() {
     timeInPercentage: number;
   }[] = [];
   let totalTimeSpent = 0;
-  props.data.forEach((dataPoint: any) => {
+  props.data.forEach((dataPoint) => {
     const activityGroup = getActivityGroupFromActivityName(dataPoint.activity);
-    const totalTime = dataPoint.end - dataPoint.start;
+    const totalTime = dataPoint.end.getTime() - dataPoint.start.getTime();
     const existingActivityGroup = activeTaskTotalTimeSpentPerActivityGroup.find(
       (item) => item.activityGroup === activityGroup
     );
@@ -239,17 +248,15 @@ function positionTooltip(event: MouseEvent, barBoundingRect: DOMRect) {
 
 function buildChart() {
   const margin = { top: 20, right: 0, bottom: 30, left: 0 };
-  const width = svgWidth - margin.left - margin.right;
-  const height = svgHeight.value - margin.top - margin.bottom;
+  const width = svgWidth.value - margin.left - margin.right;
 
   const barHeight = 35;
   const barYOffset = -10;
 
   const svg = d3
     .select(chart.value!)
-    .append('svg')
-    .attr('width', width + margin.left + margin.right)
-    .attr('height', height + margin.top + margin.bottom)
+    .attr('width', svgWidth.value)
+    .attr('height', svgHeight.value)
     .append('g')
     .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
@@ -260,29 +267,31 @@ function buildChart() {
     .attr('width', width)
     .attr('y', barYOffset)
     .attr('height', barHeight)
-    .attr('fill', isDark.value ? (Color as any)['neutral-800'] : '#e5e7eb')
+    .attr('fill', isDark.value ? Color['neutral-800'] : '#e5e7eb')
     .style('opacity', 1)
     .attr('rx', 8);
 
-  const x = d3.scaleTime().domain([chartStartDate.value!, chartEndDate.value!]).range([0, width]);
+  const x = d3.scaleTime().domain([props.startDate, props.endDate]).range([0, width]);
 
   const timeFormat = d3.timeFormat('%H:%M');
+  const formatTimeTick = (value: Date | d3.NumberValue) =>
+    timeFormat(value instanceof Date ? value : new Date(Number(value)));
 
   svg
-    .selectAll('.bar')
+    .selectAll<SVGRectElement, ChartDataPoint>('.bar')
     .data(props.data)
     .enter()
     .append('rect')
-    .attr('class', (d: any) => {
+    .attr('class', (d) => {
       return `bar bar-${getActivityGroupFromActivityName(d.activity)}`;
     })
-    .attr('x', (d: any) => x(d.start))
-    .attr('width', (d: any) => x(d.end) - x(d.start))
+    .attr('x', (d) => x(d.start))
+    .attr('width', (d) => x(d.end) - x(d.start))
     .attr('y', barYOffset)
     .attr('height', barHeight)
-    .style('fill', (d: any) => {
+    .style('fill', (d) => {
       if (d.type === DataPointType.USER_COMPUTER_ACTIVITY) {
-        return (Color as any)['neutral-400'];
+        return Color['neutral-400'];
       }
       return getBarColorFromDataPoint(d.color);
     })
@@ -318,13 +327,22 @@ function buildChart() {
   }
 
   const axisColor = isDark.value ? '#a3a3a3' : '#374151';
-  svg
+  const axisLabels = svg
     .append('g')
     .attr('class', 'x axis')
     .attr('transform', `translate(0, ${barYOffset + barHeight})`)
-    .call(d3.axisBottom(x).tickFormat(timeFormat as any))
+    .call(d3.axisBottom(x).tickFormat(formatTimeTick))
     .selectAll('text')
     .style('fill', axisColor);
+
+  const labels = axisLabels.nodes();
+  labels.forEach((label, index) => {
+    if (index === 0) {
+      d3.select(label).attr('text-anchor', 'start').attr('x', 4);
+    } else if (index === labels.length - 1) {
+      d3.select(label).attr('text-anchor', 'end').attr('x', -4);
+    }
+  });
 
   svg.selectAll('.x.axis path, .x.axis line').style('stroke', axisColor);
 }
@@ -340,9 +358,10 @@ function getLegendDataForWindowActivity(): LegendDataPoint[] {
   const activeTaskTotalTimeSpentPerActivityGroup =
     getActiveTaskTotalTimeSpentPerActivityGroupArray();
   activeTaskTotalTimeSpentPerActivityGroup.forEach((item) => {
+    const colorKey = TW_CLASS_ACTIVITY_MAPPINGS[item.activityGroup] as keyof typeof Color;
     legendData.push({
       text: `${ACTIVITY_LABELS[item.activityGroup] || 'Other'} (${msToReadableFormat(item.totalTime, false, false)})`,
-      color: (Color as any)[TW_CLASS_ACTIVITY_MAPPINGS[item.activityGroup]],
+      color: Color[colorKey],
       key: item.activityGroup
     });
   });
@@ -384,7 +403,7 @@ function drawLegend(legendData: LegendDataPoint[], enableClickableLegend = false
       const current = d3.select(this);
       const currentNodeWidth = current.node()!.getBBox().width;
       let previousWidth = totalWidth;
-      if (previousWidth + currentNodeWidth + 35 > svgWidth) {
+      if (previousWidth + currentNodeWidth + 35 > svgWidth.value) {
         startNewLinesAtItemIndex.push(i);
         totalWidth = legendStartPositionX;
         previousWidth = legendStartPositionX;
@@ -403,9 +422,9 @@ function drawLegend(legendData: LegendDataPoint[], enableClickableLegend = false
   if (enableClickableLegend) {
     d3.select(chart.value!)
       .select('.legend')
-      .selectAll('.legend-label')
+      .selectAll<SVGTextElement, LegendDataPoint>('.legend-label')
       .attr('cursor', 'pointer')
-      .on('click', function (_e: any, d: any) {
+      .on('click', function (_event: MouseEvent, d: LegendDataPoint) {
         d3.select(chart.value!).selectAll(`.legend-label`).style('opacity', null);
         d3.select(chart.value!).selectAll(`.legend-dot`).style('opacity', null);
         d3.select(chart.value!).selectAll(`.bar`).style('opacity', null);
@@ -447,34 +466,26 @@ function drawLegend(legendData: LegendDataPoint[], enableClickableLegend = false
       return d.color;
     })
     .style('opacity', 1);
-}
 
-function rebuildChartWithAnimation() {
-  chartSelectedLegendItem.value = null;
-  const margin = { top: 20, right: 20, bottom: 40, left: 20 };
-  const width = svgWidth - margin.left - margin.right;
-  const svg = d3.select(chart.value!).select('svg');
-  const x = d3.scaleTime().domain([chartStartDate.value!, chartEndDate.value!]).range([0, width]);
-
-  const bars = svg.selectAll('.bar').data(props.data);
-
-  bars
-    .transition()
-    .duration(300)
-    .attr('x', (d: any) => x(d.start))
-    .attr('width', (d: any) => x(d.end) - x(d.start))
-    .style('opacity', 1);
-
-  bars.exit().transition().duration(300).attr('width', 0).remove();
-
-  // Update legend
-  if (props.type === 'WINDOW_ACTIVITY') {
-    drawLegend(getLegendDataForWindowActivity(), true);
-  }
+  svgHeight.value = Math.max(
+    svgHeight.value,
+    legendStartPositionY + lineHeight * currentLegendItemLine + 18
+  );
 }
 </script>
 
 <style scoped>
+.stacked-bar-chart {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+}
+
+.stacked-bar-chart svg {
+  display: block;
+  max-width: 100%;
+}
+
 #tooltip {
   position: absolute;
   font-size: 12px;


### PR DESCRIPTION
# Refine retrospection dashboard layout (Closes #527)

## Description

Improves retrospection’s layout density and responsiveness so cards and timelines make effective use of wider and narrower windows.

### Changes Made

- Increase the default retrospection window size while keeping a practical minimum size.
- Use a responsive, two-, and three-column dashboard layout.
- Resize activity and self-report timeline charts with their containing cards.
- Remove the stale chart-update path and rebuild charts from current props.
- Align the first and last x-axis labels to the chart edges so timestamps remain readable.
- Preserve responsive timeline legends and chart rendering across window-size changes.

## Screenshots

| Two-column layout | Three-column layout |
|:-:|:-:|
| <img width="912" height="962" alt="retrospection_2_columns" src="https://github.com/user-attachments/assets/7da823b7-a6ef-43b8-a59c-66ba739dd718" /> | <img width="1232" height="962" alt="retrospection_3_columns" src="https://github.com/user-attachments/assets/4f6f4b38-587f-415c-a301-5bc7e07bf8e4" /> |

## Testing

- 50 targeted retrospection tests passed.
- `vue-tsc --noEmit` passed.
- Production build passed.

Closes #527