### PR TITLE
[#525] Daily Survey: Preserve Original Date for Overdue Surveys

### DIFF
--- a/documentation/RESEARCH.md
+++ b/documentation/RESEARCH.md
@@ -95,6 +95,9 @@ You can find more information on electron-builder here: https://www.electron.bui
 | `surveys[].requireAllAnswers`   | Whether all questions must be answered before the survey can be submitted. If `false`, partial submissions are allowed. Can be set independently for each survey.                                                                                                                                                                                                                         |                 | `false`       |
 | `surveys[].questions`           | An array of questions to present in the survey. All questions are shown in order. Each question uses the same format as ExperienceSamplingTracker questions and supports `answerType` values: `’LikertScale’`, `’SingleChoice’`, `’MultiChoice’`, and `’TextResponse’`.                                                                                                                    | ✅               |               |
 
+##### Overdue Daily Surveys
+If PersonalAnalytics is closed or the machine is asleep when a daily survey is due, the survey is shown at the next opportunity and keeps its **original** scheduled date. This means a response's `promptedAt` can be up to 3 calendar days after the `scheduledDate` it refers to — use `scheduledDate` when relating responses to a specific day. Surveys older than 3 calendar days are discarded without being shown (see `MAX_MISSED_SURVEY_AGE_DAYS` in [DailySurveyTracker.ts](../src/electron/electron/main/services/trackers/DailySurveyTracker.ts)). Only the most recent unanswered survey per sampling type is kept: if a new survey comes due before the previous one is answered, the older one is discarded. Participants cannot postpone a survey from a previous day.
+
 ## Contributions Guide
 Anyone is welcome to contribute to PersonalAnalytics, for example by fixing bugs, extending it with new trackers or improving existing ones.
 

--- a/src/electron/electron/ipc/IpcHandler.ts
+++ b/src/electron/electron/ipc/IpcHandler.ts
@@ -430,10 +430,15 @@ export class IpcHandler {
 
   private async postponeDailySurvey(
     samplingType: DailySurveySamplingType,
+    scheduledDate: Date | null,
     minutes: number
   ): Promise<void> {
     if (this.dailySurveyTracker) {
-      const wasPostponed = await this.dailySurveyTracker.postpone(samplingType, minutes);
+      const wasPostponed = await this.dailySurveyTracker.postpone(
+        samplingType,
+        scheduledDate ? new Date(scheduledDate) : null,
+        minutes
+      );
       if (!wasPostponed) {
         return;
       }

--- a/src/electron/electron/main/__tests__/DailySurveyTracker.test.ts
+++ b/src/electron/electron/main/__tests__/DailySurveyTracker.test.ts
@@ -4,6 +4,7 @@ import type { DailySurveyConfig } from '../../../shared/StudyConfiguration';
 const findOneByMock = jest.fn();
 const scheduleJobMock = jest.fn();
 const createDailySurveyWindowMock = jest.fn();
+const closeDailySurveyWindowMock = jest.fn();
 const logInfoMock = jest.fn();
 const logErrorMock = jest.fn();
 
@@ -41,10 +42,19 @@ const eveningSurvey: DailySurveyConfig = {
   questions: []
 };
 
+const morningSurvey: DailySurveyConfig = {
+  samplingType: 'morning',
+  delayInMinutes: 0,
+  requireAllAnswers: false,
+  questions: []
+};
+
 function createSettings(overrides: Record<string, unknown> = {}) {
   return {
     nextDailySurveyMorningInvocation: null,
     nextDailySurveyEveningInvocation: null,
+    pendingDailySurveyMorningScheduledDate: null,
+    pendingDailySurveyEveningScheduledDate: null,
     postponedDailySurveyMorningUntil: null,
     postponedDailySurveyEveningUntil: null,
     save: jest.fn(),
@@ -52,17 +62,34 @@ function createSettings(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function createTracker() {
+const workSchedule = {
+  monday: { isWorking: true, startTime: '09:00', endTime: '18:00' },
+  tuesday: { isWorking: true, startTime: '09:00', endTime: '18:00' },
+  wednesday: { isWorking: true, startTime: '09:00', endTime: '18:00' },
+  thursday: { isWorking: true, startTime: '09:00', endTime: '18:00' },
+  friday: { isWorking: true, startTime: '09:00', endTime: '18:00' },
+  saturday: { isWorking: false, startTime: '09:00', endTime: '18:00' },
+  sunday: { isWorking: false, startTime: '09:00', endTime: '18:00' }
+};
+
+function createTracker(surveys: DailySurveyConfig[] = [eveningSurvey]) {
   return new DailySurveyTracker(
-    { createDailySurveyWindow: createDailySurveyWindowMock } as never,
-    { getWorkSchedule: jest.fn() } as never,
-    [eveningSurvey]
+    {
+      createDailySurveyWindow: createDailySurveyWindowMock,
+      closeDailySurveyWindow: closeDailySurveyWindowMock
+    } as never,
+    { getWorkSchedule: jest.fn().mockResolvedValue(workSchedule) } as never,
+    surveys
   );
+}
+
+function localDate(day: number, hour: number, minute = 0): Date {
+  return new Date(2026, 4, day, hour, minute, 0, 0);
 }
 
 beforeEach(() => {
   jest.useFakeTimers();
-  jest.setSystemTime(new Date('2026-05-14T10:00:00.000Z'));
+  jest.setSystemTime(localDate(14, 10));
   jest.clearAllMocks();
   scheduleJobMock.mockReturnValue({ cancel: jest.fn() });
 });
@@ -71,10 +98,61 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-test('preserves an overdue survey date when the computer resumes on a later day', async () => {
-  const originalScheduledDate = new Date('2026-05-13T16:10:00.000Z');
+test('shows a missed survey up to three calendar days later and schedules the current workday', async () => {
+  const originalScheduledDate = localDate(15, 18);
   const settings = createSettings({
     nextDailySurveyEveningInvocation: originalScheduledDate
+  });
+
+  findOneByMock.mockResolvedValue(settings);
+  jest.setSystemTime(localDate(18, 10));
+
+  const tracker = createTracker();
+  await tracker.start();
+
+  expect(createDailySurveyWindowMock).toHaveBeenCalledWith('evening', originalScheduledDate);
+  expect(settings.pendingDailySurveyEveningScheduledDate).toEqual(originalScheduledDate);
+  expect(settings.nextDailySurveyEveningInvocation).toEqual(localDate(18, 18));
+  expect(settings.save).toHaveBeenCalledTimes(1);
+});
+
+test('does not show a missed survey from four or more calendar days ago', async () => {
+  const originalScheduledDate = localDate(10, 18);
+  const settings = createSettings({
+    nextDailySurveyEveningInvocation: originalScheduledDate
+  });
+  findOneByMock.mockResolvedValue(settings);
+
+  const tracker = createTracker();
+  await tracker.start();
+
+  expect(createDailySurveyWindowMock).not.toHaveBeenCalled();
+  expect(settings.pendingDailySurveyEveningScheduledDate).toBeNull();
+  expect(settings.nextDailySurveyEveningInvocation).toEqual(localDate(14, 18));
+  expect(settings.save).toHaveBeenCalledTimes(1);
+});
+
+test('clears a persisted missed survey after four calendar days', async () => {
+  const originalScheduledDate = localDate(10, 18);
+  const settings = createSettings({
+    pendingDailySurveyEveningScheduledDate: originalScheduledDate,
+    nextDailySurveyEveningInvocation: localDate(14, 18)
+  });
+  findOneByMock.mockResolvedValue(settings);
+
+  const tracker = createTracker();
+  await tracker.start();
+
+  expect(createDailySurveyWindowMock).not.toHaveBeenCalled();
+  expect(settings.pendingDailySurveyEveningScheduledDate).toBeNull();
+  expect(settings.nextDailySurveyEveningInvocation).toEqual(localDate(14, 18));
+  expect(settings.save).toHaveBeenCalledTimes(1);
+});
+
+test('shows the current survey after an older survey remains unanswered', async () => {
+  const missedSurveyDate = localDate(13, 18);
+  const settings = createSettings({
+    nextDailySurveyEveningInvocation: missedSurveyDate
   });
   let dueCheck: (() => Promise<void>) | undefined;
 
@@ -85,55 +163,85 @@ test('preserves an overdue survey date when the computer resumes on a later day'
   });
 
   const tracker = createTracker();
-  await tracker.resume();
+  await tracker.start();
+
+  jest.setSystemTime(localDate(14, 18, 1));
   await dueCheck?.();
 
-  expect(createDailySurveyWindowMock).toHaveBeenCalledWith('evening', originalScheduledDate);
-  expect(settings.nextDailySurveyEveningInvocation).toBe(originalScheduledDate);
-  expect(settings.save).not.toHaveBeenCalled();
+  expect(createDailySurveyWindowMock).toHaveBeenNthCalledWith(1, 'evening', missedSurveyDate);
+  expect(createDailySurveyWindowMock).toHaveBeenNthCalledWith(2, 'evening', localDate(14, 18));
+  expect(settings.pendingDailySurveyEveningScheduledDate).toEqual(localDate(14, 18));
+  expect(settings.nextDailySurveyEveningInvocation).toEqual(localDate(15, 18));
 });
 
-test('preserves an overdue survey date when the application starts on a later day', async () => {
-  const originalScheduledDate = new Date('2026-05-13T16:10:00.000Z');
+test('does not reopen an already shown survey when another survey type opens', async () => {
   const settings = createSettings({
-    nextDailySurveyEveningInvocation: originalScheduledDate
+    pendingDailySurveyMorningScheduledDate: localDate(14, 9),
+    pendingDailySurveyEveningScheduledDate: localDate(13, 18),
+    nextDailySurveyEveningInvocation: localDate(14, 18)
+  });
+  let dueCheck: (() => Promise<void>) | undefined;
+
+  findOneByMock.mockResolvedValue(settings);
+  scheduleJobMock.mockImplementation((_: string, callback: () => Promise<void>) => {
+    dueCheck = callback;
+    return { cancel: jest.fn() };
+  });
+
+  const tracker = createTracker([morningSurvey, eveningSurvey]);
+  await tracker.start();
+  await dueCheck?.();
+
+  expect(createDailySurveyWindowMock).toHaveBeenCalledTimes(2);
+  expect(createDailySurveyWindowMock).toHaveBeenNthCalledWith(1, 'morning', localDate(14, 9));
+  expect(createDailySurveyWindowMock).toHaveBeenNthCalledWith(2, 'evening', localDate(13, 18));
+});
+
+test('completing an older survey leaves the current survey scheduled', async () => {
+  const missedSurveyDate = localDate(13, 18);
+  const currentSurveyDate = localDate(14, 18);
+  const settings = createSettings({
+    pendingDailySurveyEveningScheduledDate: missedSurveyDate,
+    nextDailySurveyEveningInvocation: currentSurveyDate
   });
   findOneByMock.mockResolvedValue(settings);
 
   const tracker = createTracker();
-  await tracker.start();
+  await tracker.complete('evening', missedSurveyDate);
 
-  expect(createDailySurveyWindowMock).toHaveBeenCalledWith('evening', originalScheduledDate);
-  expect(settings.nextDailySurveyEveningInvocation).toBe(originalScheduledDate);
-  expect(settings.save).not.toHaveBeenCalled();
+  expect(settings.pendingDailySurveyEveningScheduledDate).toBeNull();
+  expect(settings.nextDailySurveyEveningInvocation).toEqual(currentSurveyDate);
+  expect(settings.save).toHaveBeenCalledTimes(1);
 });
 
 test('does not allow an overdue survey to be postponed', async () => {
+  const originalScheduledDate = localDate(13, 18);
   const settings = createSettings({
-    nextDailySurveyEveningInvocation: new Date('2026-05-13T16:10:00.000Z')
+    pendingDailySurveyEveningScheduledDate: originalScheduledDate,
+    nextDailySurveyEveningInvocation: localDate(14, 18)
   });
   findOneByMock.mockResolvedValue(settings);
 
   const tracker = createTracker();
 
-  await expect(tracker.postpone('evening', 60)).resolves.toBe(false);
+  await expect(tracker.postpone('evening', originalScheduledDate, 60)).resolves.toBe(false);
   expect(settings.postponedDailySurveyEveningUntil).toBeNull();
   expect(settings.save).not.toHaveBeenCalled();
 });
 
 test('stores a current-day postponement separately from its scheduled date', async () => {
-  const originalScheduledDate = new Date('2026-05-14T08:00:00.000Z');
+  const originalScheduledDate = localDate(14, 8);
   const settings = createSettings({
-    nextDailySurveyEveningInvocation: originalScheduledDate
+    pendingDailySurveyEveningScheduledDate: originalScheduledDate,
+    nextDailySurveyEveningInvocation: localDate(15, 18)
   });
   findOneByMock.mockResolvedValue(settings);
 
   const tracker = createTracker();
 
-  await expect(tracker.postpone('evening', 60)).resolves.toBe(true);
-  expect(settings.nextDailySurveyEveningInvocation).toBe(originalScheduledDate);
-  expect(settings.postponedDailySurveyEveningUntil).toEqual(
-    new Date('2026-05-14T11:00:00.000Z')
-  );
+  await expect(tracker.postpone('evening', originalScheduledDate, 60)).resolves.toBe(true);
+  expect(settings.pendingDailySurveyEveningScheduledDate).toEqual(originalScheduledDate);
+  expect(settings.nextDailySurveyEveningInvocation).toEqual(localDate(15, 18));
+  expect(settings.postponedDailySurveyEveningUntil).toEqual(localDate(14, 11));
   expect(settings.save).toHaveBeenCalledTimes(1);
 });

--- a/src/electron/electron/main/__tests__/DailySurveyTracker.test.ts
+++ b/src/electron/electron/main/__tests__/DailySurveyTracker.test.ts
@@ -5,8 +5,6 @@ const findOneByMock = jest.fn();
 const scheduleJobMock = jest.fn();
 const createDailySurveyWindowMock = jest.fn();
 const closeDailySurveyWindowMock = jest.fn();
-const logInfoMock = jest.fn();
-const logErrorMock = jest.fn();
 
 jest.unstable_mockModule('node-schedule', () => ({
   scheduleJob: scheduleJobMock
@@ -26,10 +24,12 @@ jest.unstable_mockModule('../services/WorkScheduleService', () => ({
   WorkScheduleService: class WorkScheduleService {}
 }));
 
+// Silences logging; no test asserts on it.
 jest.unstable_mockModule('../../config/Logger', () => ({
   default: () => ({
-    info: logInfoMock,
-    error: logErrorMock
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn()
   })
 }));
 

--- a/src/electron/electron/main/__tests__/DailySurveyTracker.test.ts
+++ b/src/electron/electron/main/__tests__/DailySurveyTracker.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals';
+import type { DailySurveyConfig } from '../../../shared/StudyConfiguration';
+
+const findOneByMock = jest.fn();
+const scheduleJobMock = jest.fn();
+const createDailySurveyWindowMock = jest.fn();
+const logInfoMock = jest.fn();
+const logErrorMock = jest.fn();
+
+jest.unstable_mockModule('node-schedule', () => ({
+  scheduleJob: scheduleJobMock
+}));
+
+jest.unstable_mockModule('../entities/Settings', () => ({
+  Settings: {
+    findOneBy: findOneByMock
+  }
+}));
+
+jest.unstable_mockModule('../services/WindowService', () => ({
+  WindowService: class WindowService {}
+}));
+
+jest.unstable_mockModule('../services/WorkScheduleService', () => ({
+  WorkScheduleService: class WorkScheduleService {}
+}));
+
+jest.unstable_mockModule('../../config/Logger', () => ({
+  default: () => ({
+    info: logInfoMock,
+    error: logErrorMock
+  })
+}));
+
+const { DailySurveyTracker } = await import('../services/trackers/DailySurveyTracker');
+
+const eveningSurvey: DailySurveyConfig = {
+  samplingType: 'evening',
+  delayInMinutes: 0,
+  requireAllAnswers: false,
+  questions: []
+};
+
+function createSettings(overrides: Record<string, unknown> = {}) {
+  return {
+    nextDailySurveyMorningInvocation: null,
+    nextDailySurveyEveningInvocation: null,
+    postponedDailySurveyMorningUntil: null,
+    postponedDailySurveyEveningUntil: null,
+    save: jest.fn(),
+    ...overrides
+  };
+}
+
+function createTracker() {
+  return new DailySurveyTracker(
+    { createDailySurveyWindow: createDailySurveyWindowMock } as never,
+    { getWorkSchedule: jest.fn() } as never,
+    [eveningSurvey]
+  );
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2026-05-14T10:00:00.000Z'));
+  jest.clearAllMocks();
+  scheduleJobMock.mockReturnValue({ cancel: jest.fn() });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test('preserves an overdue survey date when the computer resumes on a later day', async () => {
+  const originalScheduledDate = new Date('2026-05-13T16:10:00.000Z');
+  const settings = createSettings({
+    nextDailySurveyEveningInvocation: originalScheduledDate
+  });
+  let dueCheck: (() => Promise<void>) | undefined;
+
+  findOneByMock.mockResolvedValue(settings);
+  scheduleJobMock.mockImplementation((_: string, callback: () => Promise<void>) => {
+    dueCheck = callback;
+    return { cancel: jest.fn() };
+  });
+
+  const tracker = createTracker();
+  await tracker.resume();
+  await dueCheck?.();
+
+  expect(createDailySurveyWindowMock).toHaveBeenCalledWith('evening', originalScheduledDate);
+  expect(settings.nextDailySurveyEveningInvocation).toBe(originalScheduledDate);
+  expect(settings.save).not.toHaveBeenCalled();
+});
+
+test('preserves an overdue survey date when the application starts on a later day', async () => {
+  const originalScheduledDate = new Date('2026-05-13T16:10:00.000Z');
+  const settings = createSettings({
+    nextDailySurveyEveningInvocation: originalScheduledDate
+  });
+  findOneByMock.mockResolvedValue(settings);
+
+  const tracker = createTracker();
+  await tracker.start();
+
+  expect(createDailySurveyWindowMock).toHaveBeenCalledWith('evening', originalScheduledDate);
+  expect(settings.nextDailySurveyEveningInvocation).toBe(originalScheduledDate);
+  expect(settings.save).not.toHaveBeenCalled();
+});
+
+test('does not allow an overdue survey to be postponed', async () => {
+  const settings = createSettings({
+    nextDailySurveyEveningInvocation: new Date('2026-05-13T16:10:00.000Z')
+  });
+  findOneByMock.mockResolvedValue(settings);
+
+  const tracker = createTracker();
+
+  await expect(tracker.postpone('evening', 60)).resolves.toBe(false);
+  expect(settings.postponedDailySurveyEveningUntil).toBeNull();
+  expect(settings.save).not.toHaveBeenCalled();
+});
+
+test('stores a current-day postponement separately from its scheduled date', async () => {
+  const originalScheduledDate = new Date('2026-05-14T08:00:00.000Z');
+  const settings = createSettings({
+    nextDailySurveyEveningInvocation: originalScheduledDate
+  });
+  findOneByMock.mockResolvedValue(settings);
+
+  const tracker = createTracker();
+
+  await expect(tracker.postpone('evening', 60)).resolves.toBe(true);
+  expect(settings.nextDailySurveyEveningInvocation).toBe(originalScheduledDate);
+  expect(settings.postponedDailySurveyEveningUntil).toEqual(
+    new Date('2026-05-14T11:00:00.000Z')
+  );
+  expect(settings.save).toHaveBeenCalledTimes(1);
+});

--- a/src/electron/electron/main/entities/Settings.ts
+++ b/src/electron/electron/main/entities/Settings.ts
@@ -59,10 +59,16 @@ export class Settings extends BaseEntity {
   userDisabledRetrospection: number;
 
   @Column('datetime', { nullable: true })
-  nextDailySurveyMorningInvocation: Date;
+  nextDailySurveyMorningInvocation: Date | null;
 
   @Column('datetime', { nullable: true })
-  nextDailySurveyEveningInvocation: Date;
+  nextDailySurveyEveningInvocation: Date | null;
+
+  @Column('datetime', { nullable: true })
+  pendingDailySurveyMorningScheduledDate: Date | null;
+
+  @Column('datetime', { nullable: true })
+  pendingDailySurveyEveningScheduledDate: Date | null;
 
   @Column('datetime', { nullable: true })
   postponedDailySurveyMorningUntil: Date | null;

--- a/src/electron/electron/main/services/trackers/DailySurveyTracker.ts
+++ b/src/electron/electron/main/services/trackers/DailySurveyTracker.ts
@@ -12,6 +12,8 @@ import type {
 const LOG = getMainLogger('DailySurveyTracker');
 
 const weekDays = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+
+// Three days bridges a long weekend without asking participants to recall much further back.
 const MAX_MISSED_SURVEY_AGE_DAYS = 3;
 
 type DailySurveyDateField =
@@ -58,7 +60,10 @@ export class DailySurveyTracker implements Tracker {
   public async resume(): Promise<void> {
     LOG.info('Resuming DailySurveyTracker');
     this.isRunning = true;
-    await this.processSurveys();
+    // Callers do not await resume(); the check job below retries every minute.
+    await this.processSurveys().catch((error) =>
+      LOG.error(`Error processing daily surveys while resuming: ${error}`)
+    );
     this.startCheckJob();
   }
 
@@ -69,7 +74,10 @@ export class DailySurveyTracker implements Tracker {
 
   private startCheckJob(): void {
     this.checkJob?.cancel();
-    this.checkJob = schedule.scheduleJob('* * * * *', () => this.processSurveys());
+    // node-schedule ignores the returned promise; not caught inside processSurveys() so start() can still throw.
+    this.checkJob = schedule.scheduleJob('* * * * *', () =>
+      this.processSurveys().catch((error) => LOG.error(`Error processing daily surveys: ${error}`))
+    );
   }
 
   private async processSurveys(): Promise<void> {
@@ -100,12 +108,8 @@ export class DailySurveyTracker implements Tracker {
       settings[postponedUntilField] = null;
       await settings.save();
 
-      if (
-        this.activeSurvey?.samplingType === samplingType &&
-        this.activeSurvey.scheduledDate === pendingScheduledDate.getTime()
-      ) {
+      if (this.isActiveSurvey(samplingType, pendingScheduledDate)) {
         this.windowService.closeDailySurveyWindow(false, false);
-        this.activeSurvey = null;
       }
       this.clearShownSurvey(samplingType, pendingScheduledDate);
 
@@ -131,8 +135,8 @@ export class DailySurveyTracker implements Tracker {
         }
 
         // Preserve the unanswered date while scheduling the next workday independently.
+        // scheduleNextForSurvey() clears the postponed-until field.
         settings[pendingField] = nextInvocation;
-        settings[postponedUntilField] = null;
         await this.scheduleNextForSurvey(survey, settings, now);
         pendingScheduledDate = nextInvocation;
       }
@@ -157,9 +161,21 @@ export class DailySurveyTracker implements Tracker {
     this.activeSurvey = { samplingType, scheduledDate: scheduledDate.getTime() };
   }
 
+  /** Whether the given survey currently owns the daily survey window. */
+  private isActiveSurvey(samplingType: DailySurveySamplingType, scheduledDate: Date): boolean {
+    return (
+      this.activeSurvey?.samplingType === samplingType &&
+      this.activeSurvey.scheduledDate === scheduledDate.getTime()
+    );
+  }
+
+  /** Forgets that the survey was shown, so it can be shown again (e.g. after a postponement elapses). */
   private clearShownSurvey(samplingType: DailySurveySamplingType, scheduledDate: Date): void {
     if (this.shownSurveyDates.get(samplingType) === scheduledDate.getTime()) {
       this.shownSurveyDates.delete(samplingType);
+    }
+    if (this.isActiveSurvey(samplingType, scheduledDate)) {
+      this.activeSurvey = null;
     }
   }
 
@@ -225,12 +241,17 @@ export class DailySurveyTracker implements Tracker {
     return fallback;
   }
 
+  /** Returns the Settings column that stores when the *next* survey of the given type is due. */
   private getInvocationField(samplingType: DailySurveySamplingType): DailySurveyDateField {
     if (samplingType === 'morning') return 'nextDailySurveyMorningInvocation';
     if (samplingType === 'evening') return 'nextDailySurveyEveningInvocation';
     throw new Error(`Unknown samplingType: ${samplingType}`);
   }
 
+  /**
+   * Returns the Settings column that stores the *original* scheduled date of the survey still
+   * awaiting an answer, so an overdue survey is not re-dated on restart. Cleared on submit/skip.
+   */
   private getPendingScheduledDateField(
     samplingType: DailySurveySamplingType
   ): DailySurveyDateField {
@@ -239,6 +260,7 @@ export class DailySurveyTracker implements Tracker {
     throw new Error(`Unknown samplingType: ${samplingType}`);
   }
 
+  /** Returns the Settings column that stores the postponed-until timestamp for the given type. */
   private getPostponedUntilField(samplingType: DailySurveySamplingType): DailySurveyDateField {
     if (samplingType === 'morning') return 'postponedDailySurveyMorningUntil';
     if (samplingType === 'evening') return 'postponedDailySurveyEveningUntil';
@@ -256,8 +278,8 @@ export class DailySurveyTracker implements Tracker {
     return Math.floor((localDayTimestamp(newerDate) - localDayTimestamp(olderDate)) / 86_400_000);
   }
 
-  private isBeforeToday(date: Date): boolean {
-    const today = new Date();
+  private isBeforeToday(date: Date, now: Date): boolean {
+    const today = new Date(now);
     today.setHours(0, 0, 0, 0);
     const compare = new Date(date);
     compare.setHours(0, 0, 0, 0);
@@ -280,12 +302,6 @@ export class DailySurveyTracker implements Tracker {
     }
 
     this.clearShownSurvey(samplingType, scheduledDate);
-    if (
-      this.activeSurvey?.samplingType === samplingType &&
-      this.activeSurvey.scheduledDate === scheduledDate.getTime()
-    ) {
-      this.activeSurvey = null;
-    }
     settings[pendingField] = null;
     settings[this.getPostponedUntilField(samplingType)] = null;
     await settings.save();
@@ -300,12 +316,13 @@ export class DailySurveyTracker implements Tracker {
       return false;
     }
 
+    const now = new Date();
     const settings: Settings = await Settings.findOneBy({ onlyOneEntityShouldExist: 1 });
     const pendingScheduledDate = settings[this.getPendingScheduledDateField(samplingType)];
     if (
       !pendingScheduledDate ||
       pendingScheduledDate.getTime() !== scheduledDate.getTime() ||
-      this.isBeforeToday(scheduledDate)
+      this.isBeforeToday(scheduledDate, now)
     ) {
       LOG.info(
         `Daily survey (${samplingType}) was scheduled on a previous day and cannot be postponed`
@@ -313,17 +330,11 @@ export class DailySurveyTracker implements Tracker {
       return false;
     }
 
-    const newTime = new Date(Date.now() + minutes * 60 * 1000);
+    const newTime = new Date(now.getTime() + minutes * 60 * 1000);
 
     // Store postponement separately so the original scheduled day remains available for late-survey messaging.
     settings[this.getPostponedUntilField(samplingType)] = newTime;
     this.clearShownSurvey(samplingType, scheduledDate);
-    if (
-      this.activeSurvey?.samplingType === samplingType &&
-      this.activeSurvey.scheduledDate === scheduledDate.getTime()
-    ) {
-      this.activeSurvey = null;
-    }
 
     await settings.save();
     LOG.info(`Daily survey (${samplingType}) postponed by ${minutes} minutes to ${newTime}`);

--- a/src/electron/electron/main/services/trackers/DailySurveyTracker.ts
+++ b/src/electron/electron/main/services/trackers/DailySurveyTracker.ts
@@ -12,10 +12,21 @@ import type {
 const LOG = getMainLogger('DailySurveyTracker');
 
 const weekDays = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+const MAX_MISSED_SURVEY_AGE_DAYS = 3;
+
+type DailySurveyDateField =
+  | 'nextDailySurveyMorningInvocation'
+  | 'nextDailySurveyEveningInvocation'
+  | 'pendingDailySurveyMorningScheduledDate'
+  | 'pendingDailySurveyEveningScheduledDate'
+  | 'postponedDailySurveyMorningUntil'
+  | 'postponedDailySurveyEveningUntil';
 
 export class DailySurveyTracker implements Tracker {
   private checkJob: schedule.Job;
-  private openSurveyKeys = new Set<DailySurveySamplingType>();
+  private shownSurveyDates = new Map<DailySurveySamplingType, number>();
+  private activeSurvey: { samplingType: DailySurveySamplingType; scheduledDate: number } | null =
+    null;
   private readonly windowService: WindowService;
   private readonly workScheduleService: WorkScheduleService;
   private readonly surveys: DailySurveyConfig[];
@@ -35,7 +46,7 @@ export class DailySurveyTracker implements Tracker {
 
   public async start(): Promise<void> {
     try {
-      await this.scheduleAllSurveys();
+      await this.processSurveys();
       this.startCheckJob();
       this.isRunning = true;
     } catch (error) {
@@ -47,6 +58,7 @@ export class DailySurveyTracker implements Tracker {
   public async resume(): Promise<void> {
     LOG.info('Resuming DailySurveyTracker');
     this.isRunning = true;
+    await this.processSurveys();
     this.startCheckJob();
   }
 
@@ -57,73 +69,130 @@ export class DailySurveyTracker implements Tracker {
 
   private startCheckJob(): void {
     this.checkJob?.cancel();
-    this.checkJob = schedule.scheduleJob('* * * * *', async () => {
-      const settings: Settings = await Settings.findOneBy({ onlyOneEntityShouldExist: 1 });
-      const now = new Date();
-
-      for (const survey of this.surveys) {
-        const invocationField = this.getInvocationField(survey.samplingType);
-        const postponedUntilField = this.getPostponedUntilField(survey.samplingType);
-        const nextInvocation = settings[invocationField];
-        const postponedUntil = settings[postponedUntilField];
-        const isPostponed = postponedUntil && postponedUntil > now;
-        if (
-          nextInvocation &&
-          nextInvocation <= now &&
-          !isPostponed &&
-          !this.openSurveyKeys.has(survey.samplingType)
-        ) {
-          LOG.info(`Daily survey (${survey.samplingType}) is due`);
-          this.openSurveyKeys.add(survey.samplingType);
-          await this.windowService.createDailySurveyWindow(survey.samplingType, nextInvocation);
-        }
-      }
-    });
+    this.checkJob = schedule.scheduleJob('* * * * *', () => this.processSurveys());
   }
 
-  private async scheduleAllSurveys(): Promise<void> {
+  private async processSurveys(): Promise<void> {
+    const settings: Settings = await Settings.findOneBy({ onlyOneEntityShouldExist: 1 });
+    const now = new Date();
+
     for (const survey of this.surveys) {
-      const invocationField = this.getInvocationField(survey.samplingType);
-      const postponedUntilField = this.getPostponedUntilField(survey.samplingType);
-      const settings: Settings = await Settings.findOneBy({ onlyOneEntityShouldExist: 1 });
-      const now = new Date();
-      const postponedUntil = settings[postponedUntilField];
-      const isPostponed = postponedUntil && postponedUntil > now;
-      if (
-        settings[invocationField] &&
-        settings[invocationField] <= now &&
-        !isPostponed &&
-        !this.openSurveyKeys.has(survey.samplingType)
-      ) {
-        LOG.info(
-          `Daily survey (${survey.samplingType}) was due at ${settings[invocationField]}, showing now`
-        );
-        this.openSurveyKeys.add(survey.samplingType);
-        // Keep nextInvocation unchanged until submit/skip so unattended app starts do not lose the original survey date.
-        await this.windowService.createDailySurveyWindow(
-          survey.samplingType,
-          settings[invocationField]
-        );
-      } else if (!settings[invocationField]) {
-        await this.scheduleNextForSurvey(survey);
-      }
+      await this.processSurvey(survey, settings, now);
     }
   }
 
-  private async scheduleNextForSurvey(survey: DailySurveyConfig): Promise<void> {
-    const nextInvocation = await this.computeNextInvocation(survey);
-    const settings: Settings = await Settings.findOneBy({ onlyOneEntityShouldExist: 1 });
+  private async processSurvey(
+    survey: DailySurveyConfig,
+    settings: Settings,
+    now: Date
+  ): Promise<void> {
+    const samplingType = survey.samplingType;
+    const invocationField = this.getInvocationField(samplingType);
+    const pendingField = this.getPendingScheduledDateField(samplingType);
+    const postponedUntilField = this.getPostponedUntilField(samplingType);
+    let pendingScheduledDate = settings[pendingField];
 
-    settings[this.getInvocationField(survey.samplingType)] = nextInvocation;
-    settings[this.getPostponedUntilField(survey.samplingType)] = null;
+    if (pendingScheduledDate && this.isMissedSurveyExpired(pendingScheduledDate, now)) {
+      LOG.info(
+        `Daily survey (${samplingType}) from ${pendingScheduledDate} is older than ${MAX_MISSED_SURVEY_AGE_DAYS} days and will not be shown`
+      );
+      settings[pendingField] = null;
+      settings[postponedUntilField] = null;
+      await settings.save();
 
-    await settings.save();
+      if (
+        this.activeSurvey?.samplingType === samplingType &&
+        this.activeSurvey.scheduledDate === pendingScheduledDate.getTime()
+      ) {
+        this.windowService.closeDailySurveyWindow(false, false);
+        this.activeSurvey = null;
+      }
+      this.clearShownSurvey(samplingType, pendingScheduledDate);
+
+      pendingScheduledDate = null;
+    }
+
+    const nextInvocation = settings[invocationField];
+    const isPostponed = this.isSurveyPostponed(settings, samplingType, now);
+
+    if (!nextInvocation) {
+      await this.scheduleNextForSurvey(survey, settings, now);
+    } else if (nextInvocation <= now && !isPostponed) {
+      if (this.isMissedSurveyExpired(nextInvocation, now)) {
+        LOG.info(
+          `Daily survey (${samplingType}) due at ${nextInvocation} is older than ${MAX_MISSED_SURVEY_AGE_DAYS} days and will not be shown`
+        );
+        await this.scheduleNextForSurvey(survey, settings, now);
+      } else {
+        if (pendingScheduledDate && pendingScheduledDate.getTime() !== nextInvocation.getTime()) {
+          LOG.info(
+            `Replacing unanswered ${samplingType} daily survey from ${pendingScheduledDate} with the current survey`
+          );
+        }
+
+        // Preserve the unanswered date while scheduling the next workday independently.
+        settings[pendingField] = nextInvocation;
+        settings[postponedUntilField] = null;
+        await this.scheduleNextForSurvey(survey, settings, now);
+        pendingScheduledDate = nextInvocation;
+      }
+    }
+
+    if (pendingScheduledDate && !this.isSurveyPostponed(settings, samplingType, now)) {
+      await this.showPendingSurvey(samplingType, pendingScheduledDate);
+    }
+  }
+
+  private async showPendingSurvey(
+    samplingType: DailySurveySamplingType,
+    scheduledDate: Date
+  ): Promise<void> {
+    if (this.shownSurveyDates.get(samplingType) === scheduledDate.getTime()) {
+      return;
+    }
+
+    LOG.info(`Daily survey (${samplingType}) was due at ${scheduledDate}, showing now`);
+    await this.windowService.createDailySurveyWindow(samplingType, scheduledDate);
+    this.shownSurveyDates.set(samplingType, scheduledDate.getTime());
+    this.activeSurvey = { samplingType, scheduledDate: scheduledDate.getTime() };
+  }
+
+  private clearShownSurvey(samplingType: DailySurveySamplingType, scheduledDate: Date): void {
+    if (this.shownSurveyDates.get(samplingType) === scheduledDate.getTime()) {
+      this.shownSurveyDates.delete(samplingType);
+    }
+  }
+
+  private isSurveyPostponed(
+    settings: Settings,
+    samplingType: DailySurveySamplingType,
+    now: Date
+  ): boolean {
+    const postponedUntil = settings[this.getPostponedUntilField(samplingType)];
+    return postponedUntil !== null && postponedUntil > now;
+  }
+
+  private async scheduleNextForSurvey(
+    survey: DailySurveyConfig,
+    settings?: Settings,
+    now: Date = new Date()
+  ): Promise<void> {
+    const nextInvocation = await this.computeNextInvocation(survey, now);
+    const settingsToUpdate =
+      settings ?? (await Settings.findOneBy({ onlyOneEntityShouldExist: 1 }));
+
+    settingsToUpdate[this.getInvocationField(survey.samplingType)] = nextInvocation;
+    settingsToUpdate[this.getPostponedUntilField(survey.samplingType)] = null;
+
+    await settingsToUpdate.save();
     LOG.info(`Next ${survey.samplingType} daily survey scheduled for ${nextInvocation}`);
   }
 
-  private async computeNextInvocation(survey: DailySurveyConfig): Promise<Date> {
+  private async computeNextInvocation(
+    survey: DailySurveyConfig,
+    now: Date = new Date()
+  ): Promise<Date> {
     const schedule = await this.workScheduleService.getWorkSchedule();
-    const now = new Date();
 
     for (let dayOffset = 0; dayOffset <= 7; dayOffset++) {
       const candidate = new Date(now);
@@ -156,23 +225,35 @@ export class DailySurveyTracker implements Tracker {
     return fallback;
   }
 
-  private getInvocationField(
-    samplingType: DailySurveySamplingType
-  ): 'nextDailySurveyMorningInvocation' | 'nextDailySurveyEveningInvocation' {
+  private getInvocationField(samplingType: DailySurveySamplingType): DailySurveyDateField {
     if (samplingType === 'morning') return 'nextDailySurveyMorningInvocation';
     if (samplingType === 'evening') return 'nextDailySurveyEveningInvocation';
     throw new Error(`Unknown samplingType: ${samplingType}`);
   }
 
-  /**
-   * Returns the Settings column that stores the postponed-until timestamp for the given daily survey type.
-   */
-  private getPostponedUntilField(
+  private getPendingScheduledDateField(
     samplingType: DailySurveySamplingType
-  ): 'postponedDailySurveyMorningUntil' | 'postponedDailySurveyEveningUntil' {
+  ): DailySurveyDateField {
+    if (samplingType === 'morning') return 'pendingDailySurveyMorningScheduledDate';
+    if (samplingType === 'evening') return 'pendingDailySurveyEveningScheduledDate';
+    throw new Error(`Unknown samplingType: ${samplingType}`);
+  }
+
+  private getPostponedUntilField(samplingType: DailySurveySamplingType): DailySurveyDateField {
     if (samplingType === 'morning') return 'postponedDailySurveyMorningUntil';
     if (samplingType === 'evening') return 'postponedDailySurveyEveningUntil';
     throw new Error(`Unknown samplingType: ${samplingType}`);
+  }
+
+  private isMissedSurveyExpired(scheduledDate: Date, now: Date): boolean {
+    return this.getLocalCalendarDayDifference(scheduledDate, now) > MAX_MISSED_SURVEY_AGE_DAYS;
+  }
+
+  private getLocalCalendarDayDifference(olderDate: Date, newerDate: Date): number {
+    const localDayTimestamp = (date: Date): number =>
+      Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
+
+    return Math.floor((localDayTimestamp(newerDate) - localDayTimestamp(olderDate)) / 86_400_000);
   }
 
   private isBeforeToday(date: Date): boolean {
@@ -187,24 +268,45 @@ export class DailySurveyTracker implements Tracker {
     samplingType: DailySurveySamplingType,
     scheduledDate?: Date | null
   ): Promise<void> {
-    this.openSurveyKeys.delete(samplingType);
-
     if (!scheduledDate) {
       return;
     }
 
-    const survey = this.surveys.find((s) => s.samplingType === samplingType);
-    if (!survey) {
-      throw new Error(`Unknown daily survey samplingType: ${samplingType}`);
+    const settings: Settings = await Settings.findOneBy({ onlyOneEntityShouldExist: 1 });
+    const pendingField = this.getPendingScheduledDateField(samplingType);
+    const pendingScheduledDate = settings[pendingField];
+    if (!pendingScheduledDate || pendingScheduledDate.getTime() !== scheduledDate.getTime()) {
+      return;
     }
 
-    await this.scheduleNextForSurvey(survey);
+    this.clearShownSurvey(samplingType, scheduledDate);
+    if (
+      this.activeSurvey?.samplingType === samplingType &&
+      this.activeSurvey.scheduledDate === scheduledDate.getTime()
+    ) {
+      this.activeSurvey = null;
+    }
+    settings[pendingField] = null;
+    settings[this.getPostponedUntilField(samplingType)] = null;
+    await settings.save();
   }
 
-  public async postpone(samplingType: DailySurveySamplingType, minutes: number): Promise<boolean> {
+  public async postpone(
+    samplingType: DailySurveySamplingType,
+    scheduledDate: Date | null,
+    minutes: number
+  ): Promise<boolean> {
+    if (!scheduledDate) {
+      return false;
+    }
+
     const settings: Settings = await Settings.findOneBy({ onlyOneEntityShouldExist: 1 });
-    const scheduledDate = settings[this.getInvocationField(samplingType)];
-    if (scheduledDate && this.isBeforeToday(scheduledDate)) {
+    const pendingScheduledDate = settings[this.getPendingScheduledDateField(samplingType)];
+    if (
+      !pendingScheduledDate ||
+      pendingScheduledDate.getTime() !== scheduledDate.getTime() ||
+      this.isBeforeToday(scheduledDate)
+    ) {
       LOG.info(
         `Daily survey (${samplingType}) was scheduled on a previous day and cannot be postponed`
       );
@@ -215,7 +317,13 @@ export class DailySurveyTracker implements Tracker {
 
     // Store postponement separately so the original scheduled day remains available for late-survey messaging.
     settings[this.getPostponedUntilField(samplingType)] = newTime;
-    this.openSurveyKeys.delete(samplingType);
+    this.clearShownSurvey(samplingType, scheduledDate);
+    if (
+      this.activeSurvey?.samplingType === samplingType &&
+      this.activeSurvey.scheduledDate === scheduledDate.getTime()
+    ) {
+      this.activeSurvey = null;
+    }
 
     await settings.save();
     LOG.info(`Daily survey (${samplingType}) postponed by ${minutes} minutes to ${newTime}`);

--- a/src/electron/src/utils/Commands.ts
+++ b/src/electron/src/utils/Commands.ts
@@ -79,7 +79,11 @@ type Commands = {
   ) => Promise<void>;
   resizeDailySurveyWindow: (height: number) => void;
   closeDailySurveyWindow: (skipped: boolean) => void;
-  postponeDailySurvey: (samplingType: DailySurveySamplingType, minutes: number) => Promise<void>;
+  postponeDailySurvey: (
+    samplingType: DailySurveySamplingType,
+    scheduledDate: Date | null,
+    minutes: number
+  ) => Promise<void>;
   getMostRecentDailySurveyDtos: (itemCount: number) => Promise<DailySurveyDto[]>;
 };
 export default Commands;

--- a/src/electron/src/views/DailySurveyView.vue
+++ b/src/electron/src/views/DailySurveyView.vue
@@ -126,7 +126,7 @@ async function skipSurvey() {
 }
 
 async function postpone(minutes: number) {
-  await typedIpcRenderer.invoke('postponeDailySurvey', samplingType, minutes);
+  await typedIpcRenderer.invoke('postponeDailySurvey', samplingType, scheduledDate, minutes);
 }
 </script>
 <template>


### PR DESCRIPTION
# Daily Survey: Preserve Original Date for Overdue Surveys (Closes #525)

## Description

Fixes daily surveys being reassigned to a newer day when PersonalAnalytics reopens after an unattended system resume or application restart.

An overdue survey now retains its original scheduled date until it is answered or skipped. Previous-day surveys show their original date and cannot be postponed.