### PR TITLE
Fix AppIconHelper macOS icon test on the Windows runner

### DIFF
--- a/src/electron/electron/main/__tests__/AppIconHelper.test.ts
+++ b/src/electron/electron/main/__tests__/AppIconHelper.test.ts
@@ -201,6 +201,18 @@ jest.unstable_mockModule('extract-file-icon', () => ({
 
 const { getProcessIconDataUrl } = await import('../services/utils/AppIconHelper');
 
+// AppIconHelper gates its macOS code paths on process.platform, so those tests have to fake it.
+async function withPlatform(platform: NodeJS.Platform, run: () => Promise<void>): Promise<void> {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+
+  try {
+    await run();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  }
+}
+
 beforeEach(() => {
   getFileIconMock.mockClear();
   createFromPathMock.mockClear();
@@ -268,10 +280,13 @@ test('falls back to the Electron shell icon when no Windows visual elements mani
   expect(getFileIconMock).toHaveBeenCalledWith(SHELL_ICON_PROCESS_PATH, { size: 'small' });
 });
 
-test('converts macOS icns app icons when Electron cannot load them directly', async () => {
-  await expect(getProcessIconDataUrl(MAC_WORD_PROCESS_PATH, 'Microsoft Word')).resolves.toBe(
-    'data:image/png;base64,mac-word'
-  );
+test('converts macOS .icns app icons when Electron cannot load them directly', async () => {
+  await withPlatform('darwin', async () => {
+    await expect(getProcessIconDataUrl(MAC_WORD_PROCESS_PATH, 'Microsoft Word')).resolves.toBe(
+      'data:image/png;base64,mac-word'
+    );
+  });
+
   expect(createFromPathMock).toHaveBeenCalledWith(MAC_WORD_ICON_PATH);
   expect(execFileSyncMock).toHaveBeenCalledWith(
     '/usr/bin/sips',

--- a/src/electron/electron/main/services/utils/AppIconHelper.ts
+++ b/src/electron/electron/main/services/utils/AppIconHelper.ts
@@ -298,8 +298,8 @@ function getWindowsAppsPackageIconDataUrl(
 }
 
 function getMacIcnsDataUrlViaSips(iconPath: string): string | undefined {
-  const tempDirectory = mkdtempSync(path.join(tmpdir(), 'personal-analytics-icon-'));
-  const pngPath = path.join(tempDirectory, 'icon.png');
+  const tempDirectory = mkdtempSync(path.posix.join(tmpdir(), 'personal-analytics-icon-'));
+  const pngPath = path.posix.join(tempDirectory, 'icon.png');
 
   try {
     execFileSync('/usr/bin/sips', ['-s', 'format', 'png', '--out', pngPath, iconPath], {
@@ -324,7 +324,7 @@ function getBundleResourceIconDataUrl(
   appBundlePath: string,
   processName: string | null
 ): string | undefined {
-  const resourcesPath = path.join(appBundlePath, 'Contents', 'Resources');
+  const resourcesPath = path.posix.join(appBundlePath, 'Contents', 'Resources');
   if (!existsSync(resourcesPath)) {
     return undefined;
   }
@@ -340,7 +340,9 @@ function getBundleResourceIconDataUrl(
       })
     : [];
 
-  const plistIconFile = getPlistIconFileName(path.join(appBundlePath, 'Contents', 'Info.plist'));
+  const plistIconFile = getPlistIconFileName(
+    path.posix.join(appBundlePath, 'Contents', 'Info.plist')
+  );
   const plistIconCandidates = plistIconFile
     ? [
         plistIconFile,
@@ -369,7 +371,7 @@ function getBundleResourceIconDataUrl(
     }
     seenFiles.add(file);
 
-    const iconDataUrl = getIconDataUrlFromPath(path.join(resourcesPath, file));
+    const iconDataUrl = getIconDataUrlFromPath(path.posix.join(resourcesPath, file));
     if (iconDataUrl) {
       return iconDataUrl;
     }


### PR DESCRIPTION
## Problem

`npm test` currently fails on `windows-latest`, so the Windows leg of the build matrix never reaches the Build step and produces no installer:

```
● converts macOS icns app icons when Electron cannot load them directly
  Expected: "data:image/png;base64,mac-word"
  Received: undefined
```

The test only ever passed on the macOS runners. Two host-dependent assumptions were at fault:

1. The test never stubbed `process.platform`, so the darwin-gated sips branch in `getIconDataUrlFromPath` was unreachable off macOS.
2. The macOS-only helpers in `AppIconHelper` join paths with the host default `path` module. On Windows that turns `/Applications/Microsoft Word.app` + `Contents/Resources` into `/Applications/Microsoft Word.app\Contents\Resources`, which can never match an `.app` bundle — so the mocked `existsSync` returned false and the whole chain bailed out.

## Fix

- Added a `withPlatform` test helper that stubs `process.platform` and restores it in a `finally`, wrapped around the one call that needs darwin.
- Pinned the four joins in `getMacIcnsDataUrlViaSips` and `getBundleResourceIconDataUrl` to `path.posix`. Those helpers only ever receive posix `.app` bundle paths (from `getMacAppBundlePath`, which regex-matches `.app`), so `path.posix.join === path.join` on darwin and production behaviour there is unchanged. The file already uses this idiom in `getPathModuleForProcessPath`, which picks `path.win32` vs `path` deliberately.

Also spelled the format as `.icns` in the test name so it doesn't read as a misspelling of "icons".

## Testing

Full suite on Windows, was 1 failed / 62 passed:

```
Test Suites: 5 passed, 5 total
Tests:       63 passed, 63 total
```

Not verified by execution on macOS — the argument that those runners are unaffected is that `path.posix.join === path.join` on darwin, and `withPlatform('darwin', …)` is a no-op there, with the assertions and the expected sips path unchanged from the version that already passed.

## Note, out of scope here

While digging into this I found that the four test files in the `PA.UserInputTracker` and `PA.WindowsActivityTracker` submodules never run in CI at all — the root jest config's `roots` exclude them, and the root `npm ci` does not install the devDependencies of `file:` dependencies, so there is no jest in those trees. Worth a separate issue; deliberately not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)