### PR TITLE
[#571] Fix Retrospection When Switching Timezones

### DIFF
--- a/src/electron/electron/ipc/IpcHandler.ts
+++ b/src/electron/electron/ipc/IpcHandler.ts
@@ -42,7 +42,10 @@ import type {
   DailySurveySamplingType,
   ExperienceSamplingAnswerType
 } from '../../shared/StudyConfiguration';
-import type { RetrospectionWorkdayRange } from '../../shared/retrospection/Workday';
+import {
+  normalizeRetrospectionWorkdayRange,
+  type RetrospectionWorkdayRange
+} from '../../shared/retrospection/Workday';
 import { DailySurveyTracker } from '../main/services/trackers/DailySurveyTracker';
 import { UsageDataService } from '../main/services/UsageDataService';
 import { UsageDataEventType } from '../enums/UsageDataEventType.enum';
@@ -347,16 +350,16 @@ export class IpcHandler {
   }
 
   private async retrospectionGetActivities(workdayRange: RetrospectionWorkdayRange): Promise<ActivitySessions[]> {
-    return await getActivitySessions(workdayRange);
+    return await getActivitySessions(normalizeRetrospectionWorkdayRange(workdayRange));
   }
 
   private async retrospectionGetActiveHours(workdayRange: RetrospectionWorkdayRange) {
-    return await getActiveHoursInsight(workdayRange);
+    return await getActiveHoursInsight(normalizeRetrospectionWorkdayRange(workdayRange));
   }
 
   private async retrospectionLoadLongestTimeActive(workdayRange: RetrospectionWorkdayRange): Promise<TimeActive | undefined> {
     try {
-      return await getLongestTimeActiveInsight(workdayRange);
+      return await getLongestTimeActiveInsight(normalizeRetrospectionWorkdayRange(workdayRange));
     } catch (error) {
       LOG.error('Error loading longest time active', error);
     }
@@ -366,7 +369,7 @@ export class IpcHandler {
     workdayRange: RetrospectionWorkdayRange
   ): Promise<ActivitySessions[] | undefined> {
     try {
-      return (await getAppUsageSessions(workdayRange))
+      return (await getAppUsageSessions(normalizeRetrospectionWorkdayRange(workdayRange)))
         .sort((a, b) => b.totalDurationMs - a.totalDurationMs)
         .slice(0, 3);
     } catch (error) {
@@ -378,7 +381,7 @@ export class IpcHandler {
     workdayRange: RetrospectionWorkdayRange
   ): Promise<ActivitySessions[] | undefined> {
     try {
-      return await getTopWebsiteSessions(workdayRange, 3);
+      return await getTopWebsiteSessions(normalizeRetrospectionWorkdayRange(workdayRange), 3);
     } catch (error) {
       LOG.error('Error loading top websites', error);
     }
@@ -388,14 +391,16 @@ export class IpcHandler {
     workdayRange: RetrospectionWorkdayRange
   ): Promise<ActivitySessions[] | undefined> {
     try {
-      return await getTopWindowTitleSessions(workdayRange, 3);
+      return await getTopWindowTitleSessions(normalizeRetrospectionWorkdayRange(workdayRange), 3);
     } catch (error) {
       LOG.error('Error loading top window titles', error);
     }
   }
 
   private async retrospectionGetSelfReports(workdayRange: RetrospectionWorkdayRange): Promise<ExperienceSamplingDto[]> {
-    return await this.experienceSamplingService.getExperienceSamplingDtosForDay(workdayRange);
+    return await this.experienceSamplingService.getExperienceSamplingDtosForDay(
+      normalizeRetrospectionWorkdayRange(workdayRange)
+    );
   }
 
   private async openRetrospection(): Promise<void> {

--- a/src/electron/electron/ipc/IpcHandler.ts
+++ b/src/electron/electron/ipc/IpcHandler.ts
@@ -42,6 +42,7 @@ import type {
   DailySurveySamplingType,
   ExperienceSamplingAnswerType
 } from '../../shared/StudyConfiguration';
+import type { RetrospectionWorkdayRange } from '../../shared/retrospection/Workday';
 import { DailySurveyTracker } from '../main/services/trackers/DailySurveyTracker';
 import { UsageDataService } from '../main/services/UsageDataService';
 import { UsageDataEventType } from '../enums/UsageDataEventType.enum';
@@ -345,27 +346,27 @@ export class IpcHandler {
     }
   }
 
-  private async retrospectionGetActivities(date: Date): Promise<ActivitySessions[]> {
-    return await getActivitySessions(new Date(date));
+  private async retrospectionGetActivities(workdayRange: RetrospectionWorkdayRange): Promise<ActivitySessions[]> {
+    return await getActivitySessions(workdayRange);
   }
 
-  private async retrospectionGetActiveHours(date: Date) {
-    return await getActiveHoursInsight(new Date(date));
+  private async retrospectionGetActiveHours(workdayRange: RetrospectionWorkdayRange) {
+    return await getActiveHoursInsight(workdayRange);
   }
 
-  private async retrospectionLoadLongestTimeActive(date: Date): Promise<TimeActive | undefined> {
+  private async retrospectionLoadLongestTimeActive(workdayRange: RetrospectionWorkdayRange): Promise<TimeActive | undefined> {
     try {
-      return await getLongestTimeActiveInsight(new Date(date));
+      return await getLongestTimeActiveInsight(workdayRange);
     } catch (error) {
       LOG.error('Error loading longest time active', error);
     }
   }
 
   private async retrospectionGetTopThreeMostActiveApps(
-    date: Date
+    workdayRange: RetrospectionWorkdayRange
   ): Promise<ActivitySessions[] | undefined> {
     try {
-      return (await getAppUsageSessions(new Date(date)))
+      return (await getAppUsageSessions(workdayRange))
         .sort((a, b) => b.totalDurationMs - a.totalDurationMs)
         .slice(0, 3);
     } catch (error) {
@@ -374,27 +375,27 @@ export class IpcHandler {
   }
 
   private async retrospectionGetTopThreeWebsites(
-    date: Date
+    workdayRange: RetrospectionWorkdayRange
   ): Promise<ActivitySessions[] | undefined> {
     try {
-      return await getTopWebsiteSessions(new Date(date), 3);
+      return await getTopWebsiteSessions(workdayRange, 3);
     } catch (error) {
       LOG.error('Error loading top websites', error);
     }
   }
 
   private async retrospectionGetTopThreeWindowTitles(
-    date: Date
+    workdayRange: RetrospectionWorkdayRange
   ): Promise<ActivitySessions[] | undefined> {
     try {
-      return await getTopWindowTitleSessions(new Date(date), 3);
+      return await getTopWindowTitleSessions(workdayRange, 3);
     } catch (error) {
       LOG.error('Error loading top window titles', error);
     }
   }
 
-  private async retrospectionGetSelfReports(date: Date): Promise<ExperienceSamplingDto[]> {
-    return await this.experienceSamplingService.getExperienceSamplingDtosForDay(new Date(date));
+  private async retrospectionGetSelfReports(workdayRange: RetrospectionWorkdayRange): Promise<ExperienceSamplingDto[]> {
+    return await this.experienceSamplingService.getExperienceSamplingDtosForDay(workdayRange);
   }
 
   private async openRetrospection(): Promise<void> {

--- a/src/electron/electron/main/__tests__/ExperienceSamplingService.test.ts
+++ b/src/electron/electron/main/__tests__/ExperienceSamplingService.test.ts
@@ -31,31 +31,20 @@ beforeEach(() => {
   createQueryBuilder.mockReturnValue({ where });
 });
 
-test('self-reports are queried using the selected 04:00-to-04:00 local workday', async () => {
+test('self-reports are queried using the selected workday', async () => {
   const service = new ExperienceSamplingService();
+  const workdayRange = {
+    start: new Date('2026-06-29T04:00:00.000Z'),
+    end: new Date('2026-06-30T04:00:00.000Z')
+  };
 
-  await service.getExperienceSamplingDtosForDay(new Date(2026, 5, 29, 0, 0));
+  await service.getExperienceSamplingDtosForDay(workdayRange);
 
   expect(createQueryBuilder).toHaveBeenCalledWith('experienceSampling');
-  expect(where).toHaveBeenCalledWith(
-    "datetime(experienceSampling.promptedAt, 'localtime') >= :workdayStart",
-    { workdayStart: '2026-06-29 04:00:00' }
-  );
-  expect(andWhere).toHaveBeenCalledWith(
-    "datetime(experienceSampling.promptedAt, 'localtime') < :workdayEnd",
-    { workdayEnd: '2026-06-30 04:00:00' }
-  );
-});
-
-test('date-only self-report queries do not pass through UTC date conversion', async () => {
-  const service = new ExperienceSamplingService();
-
-  await service.getExperienceSamplingDtosForDay('2026-06-29');
-
-  expect(where).toHaveBeenCalledWith(expect.any(String), {
+  expect(where).toHaveBeenCalledWith('experienceSampling.promptedAt >= :workdayStart', {
     workdayStart: '2026-06-29 04:00:00'
   });
-  expect(andWhere).toHaveBeenCalledWith(expect.any(String), {
+  expect(andWhere).toHaveBeenCalledWith('experienceSampling.promptedAt < :workdayEnd', {
     workdayEnd: '2026-06-30 04:00:00'
   });
 });

--- a/src/electron/electron/main/__tests__/RetrospectionWorkdayData.test.ts
+++ b/src/electron/electron/main/__tests__/RetrospectionWorkdayData.test.ts
@@ -52,12 +52,16 @@ test('loads each raw tracker source once for the whole workday', async () => {
     .spyOn(UserInputEntity, 'createQueryBuilder')
     .mockReturnValue(inputBuilder as never);
 
-  const workdayData = await loadRetrospectionWorkdayData(new Date(2026, 6, 14));
+  const workdayRange = {
+    start: new Date('2026-07-14T04:00:00.000Z'),
+    end: new Date('2026-07-15T04:00:00.000Z')
+  };
+  const workdayData = await loadRetrospectionWorkdayData(workdayRange);
 
   expect(windowQuery).toHaveBeenCalledTimes(1);
   expect(inputQuery).toHaveBeenCalledTimes(1);
   expect(workdayData.windowActivities).toHaveLength(1);
   expect(workdayData.windowActivities[0].ts).toBeInstanceOf(Date);
   expect(workdayData.activeMinutes).toEqual(new Set([5 * 60]));
-  expect(workdayData.workdayStart).toEqual(new Date(2026, 6, 14, 4));
+  expect(workdayData.workdayStart).toEqual(workdayRange.start);
 });

--- a/src/electron/electron/main/services/ExperienceSamplingService.ts
+++ b/src/electron/electron/main/services/ExperienceSamplingService.ts
@@ -4,8 +4,8 @@ import ExperienceSamplingDto from '../../../shared/dto/ExperienceSamplingDto';
 import type { ExperienceSamplingResponseInput } from '../../../shared/dto/ExperienceSamplingDto';
 import type { ExperienceSamplingAnswerType } from '../../../shared/StudyConfiguration';
 import {
-  formatSqliteLocalDateTime,
-  getRetrospectionWorkdayRange
+  formatSqliteUtcDateTime,
+  type RetrospectionWorkdayRange
 } from '../../../shared/retrospection/Workday';
 
 const LOG = getMainLogger('ExperienceSamplingService');
@@ -87,18 +87,17 @@ export class ExperienceSamplingService {
   }
 
   public async getExperienceSamplingDtosForDay(
-    date: Date | string
+    workdayRange: RetrospectionWorkdayRange
   ): Promise<ExperienceSamplingDto[]> {
-    const workdayRange = getRetrospectionWorkdayRange(date);
-    const workdayStart = formatSqliteLocalDateTime(workdayRange.start);
-    const workdayEnd = formatSqliteLocalDateTime(workdayRange.end);
+    const workdayStart = formatSqliteUtcDateTime(workdayRange.start);
+    const workdayEnd = formatSqliteUtcDateTime(workdayRange.end);
     const experienceSamplingResponses = await ExperienceSamplingResponseEntity.createQueryBuilder(
       'experienceSampling'
     )
-      .where("datetime(experienceSampling.promptedAt, 'localtime') >= :workdayStart", {
+      .where('experienceSampling.promptedAt >= :workdayStart', {
         workdayStart
       })
-      .andWhere("datetime(experienceSampling.promptedAt, 'localtime') < :workdayEnd", {
+      .andWhere('experienceSampling.promptedAt < :workdayEnd', {
         workdayEnd
       })
       .orderBy('experienceSampling.promptedAt', 'ASC')

--- a/src/electron/electron/main/services/RetrospectionService.ts
+++ b/src/electron/electron/main/services/RetrospectionService.ts
@@ -22,6 +22,7 @@ import {
 import { buildAppUsageFigure, buildTopAppsFigure } from './retrospection/figures/TopAppsFigure';
 import { buildTopWebsitesFigure } from './retrospection/figures/TopWebsitesFigure';
 import { buildTopWindowTitlesFigure } from './retrospection/figures/TopWindowTitlesFigure';
+import type { RetrospectionWorkdayRange } from '../../../shared/retrospection/Workday';
 
 const LOG = getMainLogger('RetrospectionService');
 
@@ -64,11 +65,11 @@ function emptyActivityDashboard(
  * sections unavailable because none of them can be calculated without the raw tracker data.
  */
 export async function getRetrospectionActivityDashboard(
-  date: Date
+  workdayRange: RetrospectionWorkdayRange
 ): Promise<RetrospectionActivityDashboard> {
   let workdayData: RetrospectionWorkdayData;
   try {
-    workdayData = await loadRetrospectionWorkdayData(date);
+    workdayData = await loadRetrospectionWorkdayData(workdayRange);
   } catch (error) {
     LOG.error('Error loading retrospection workday data', error);
     return emptyActivityDashboard([...ACTIVITY_SECTION_ORDER]);
@@ -117,35 +118,35 @@ export async function getRetrospectionActivityDashboard(
 // Compatibility façade for callers and focused tests. Dashboard IPC uses the shared workday data.
 export const getWindowActivities = getWindowActivitiesForWorkday;
 
-export async function getActiveHoursInsight(date: Date): Promise<ActiveHoursInsight> {
-  return buildActiveHoursFigure(await loadRetrospectionWorkdayData(date));
+export async function getActiveHoursInsight(workdayRange: RetrospectionWorkdayRange): Promise<ActiveHoursInsight> {
+  return buildActiveHoursFigure(await loadRetrospectionWorkdayData(workdayRange));
 }
 
-export async function getLongestTimeActiveInsight(date: Date): Promise<TimeActive> {
-  return buildLongestActivePeriodFigure(await loadRetrospectionWorkdayData(date));
+export async function getLongestTimeActiveInsight(workdayRange: RetrospectionWorkdayRange): Promise<TimeActive> {
+  return buildLongestActivePeriodFigure(await loadRetrospectionWorkdayData(workdayRange));
 }
 
-export async function getAppUsageSessions(date: Date): Promise<ActivitySessions[]> {
-  return buildAppUsageFigure(await loadRetrospectionWorkdayData(date));
+export async function getAppUsageSessions(workdayRange: RetrospectionWorkdayRange): Promise<ActivitySessions[]> {
+  return buildAppUsageFigure(await loadRetrospectionWorkdayData(workdayRange));
 }
 
-export async function getTopWebsiteSessions(date: Date, limit = 3): Promise<ActivitySessions[]> {
-  return buildTopWebsitesFigure(await loadRetrospectionWorkdayData(date), limit);
+export async function getTopWebsiteSessions(workdayRange: RetrospectionWorkdayRange, limit = 3): Promise<ActivitySessions[]> {
+  return buildTopWebsitesFigure(await loadRetrospectionWorkdayData(workdayRange), limit);
 }
 
 export async function getTopWindowTitleSessions(
-  date: Date,
+  workdayRange: RetrospectionWorkdayRange,
   limit = 3
 ): Promise<ActivitySessions[]> {
-  return buildTopWindowTitlesFigure(await loadRetrospectionWorkdayData(date), limit);
+  return buildTopWindowTitlesFigure(await loadRetrospectionWorkdayData(workdayRange), limit);
 }
 
 export async function getActivitySessions(
-  date: Date,
+  workdayRange: RetrospectionWorkdayRange,
   excludeUnspecificActivities = true
 ): Promise<ActivitySessions[]> {
   return await buildActivityTimelineFigure(
-    await loadRetrospectionWorkdayData(date),
+    await loadRetrospectionWorkdayData(workdayRange),
     excludeUnspecificActivities
   );
 }

--- a/src/electron/electron/main/services/retrospection/RetrospectionWorkdayData.ts
+++ b/src/electron/electron/main/services/retrospection/RetrospectionWorkdayData.ts
@@ -33,6 +33,9 @@ export interface RetrospectionWorkdayData {
 export async function getActiveMinutesForWorkday(workdayRange: RetrospectionWorkdayRange): Promise<Set<number>> {
   const workdayStart = formatSqliteUtcDateTime(workdayRange.start);
   const workdayEnd = formatSqliteUtcDateTime(workdayRange.end);
+  const workdayMinuteCount = Math.round(
+    (workdayRange.end.getTime() - workdayRange.start.getTime()) / 60_000
+  );
   const userInput = await UserInputEntity.createQueryBuilder('userInput')
     .select(['userInput.*'])
     .where('userInput.tsStart >= :workdayStart', { workdayStart })
@@ -49,7 +52,7 @@ export async function getActiveMinutesForWorkday(workdayRange: RetrospectionWork
       (entry.movedDistance ?? 0) > 0
     ) {
       const minuteIndex = getWorkdayMinuteIndex(parseSqliteUtcDateTime(entry.tsStart), workdayRange.start);
-      if (minuteIndex >= 0 && minuteIndex < 24 * 60) {
+      if (minuteIndex >= 0 && minuteIndex < workdayMinuteCount) {
         activeMinutes.add(minuteIndex);
       }
     }

--- a/src/electron/electron/main/services/retrospection/RetrospectionWorkdayData.ts
+++ b/src/electron/electron/main/services/retrospection/RetrospectionWorkdayData.ts
@@ -5,9 +5,10 @@
 import { UserInputEntity } from '../../entities/UserInputEntity';
 import { WindowActivityEntity } from '../../entities/WindowActivityEntity';
 import {
-  formatSqliteLocalDateTime,
-  getRetrospectionWorkdayRange,
-  getWorkdayMinuteIndex
+  formatSqliteUtcDateTime,
+  getWorkdayMinuteIndex,
+  parseSqliteUtcDateTime,
+  type RetrospectionWorkdayRange
 } from '../../../../shared/retrospection/Workday';
 
 interface RawUserInput {
@@ -29,14 +30,13 @@ export interface RetrospectionWorkdayData {
   workdayStart: Date;
 }
 
-export async function getActiveMinutesForWorkday(date: Date | string): Promise<Set<number>> {
-  const { start, end } = getRetrospectionWorkdayRange(date);
-  const workdayStart = formatSqliteLocalDateTime(start);
-  const workdayEnd = formatSqliteLocalDateTime(end);
+export async function getActiveMinutesForWorkday(workdayRange: RetrospectionWorkdayRange): Promise<Set<number>> {
+  const workdayStart = formatSqliteUtcDateTime(workdayRange.start);
+  const workdayEnd = formatSqliteUtcDateTime(workdayRange.end);
   const userInput = await UserInputEntity.createQueryBuilder('userInput')
-    .select(['userInput.*', "datetime(userInput.tsStart, 'localtime') as tsStart"])
-    .where("datetime(userInput.tsStart, 'localtime') >= :workdayStart", { workdayStart })
-    .andWhere("datetime(userInput.tsStart, 'localtime') < :workdayEnd", { workdayEnd })
+    .select(['userInput.*'])
+    .where('userInput.tsStart >= :workdayStart', { workdayStart })
+    .andWhere('userInput.tsStart < :workdayEnd', { workdayEnd })
     .orderBy('userInput.tsStart', 'ASC')
     .getRawMany<RawUserInput>();
 
@@ -48,7 +48,7 @@ export async function getActiveMinutesForWorkday(date: Date | string): Promise<S
       (entry.scrollDelta ?? 0) > 0 ||
       (entry.movedDistance ?? 0) > 0
     ) {
-      const minuteIndex = getWorkdayMinuteIndex(new Date(entry.tsStart), start);
+      const minuteIndex = getWorkdayMinuteIndex(parseSqliteUtcDateTime(entry.tsStart), workdayRange.start);
       if (minuteIndex >= 0 && minuteIndex < 24 * 60) {
         activeMinutes.add(minuteIndex);
       }
@@ -59,30 +59,28 @@ export async function getActiveMinutesForWorkday(date: Date | string): Promise<S
 }
 
 export async function getWindowActivitiesForWorkday(
-  date: Date | string
+  workdayRange: RetrospectionWorkdayRange
 ): Promise<WindowActivityEntity[]> {
-  const { start, end } = getRetrospectionWorkdayRange(date);
-  const workdayStart = formatSqliteLocalDateTime(start);
-  const workdayEnd = formatSqliteLocalDateTime(end);
+  const workdayStart = formatSqliteUtcDateTime(workdayRange.start);
+  const workdayEnd = formatSqliteUtcDateTime(workdayRange.end);
   const rows = await WindowActivityEntity.createQueryBuilder('windowActivity')
-    .select(['windowActivity.*', "datetime(windowActivity.ts, 'localtime') as ts"])
-    .where("datetime(windowActivity.ts, 'localtime') >= :workdayStart", { workdayStart })
-    .andWhere("datetime(windowActivity.ts, 'localtime') < :workdayEnd", { workdayEnd })
+    .select(['windowActivity.*'])
+    .where('windowActivity.ts >= :workdayStart', { workdayStart })
+    .andWhere('windowActivity.ts < :workdayEnd', { workdayEnd })
     .orderBy('windowActivity.ts', 'ASC')
     .getRawMany<RawWindowActivity>();
 
-  return rows.map((row) => ({ ...row, ts: new Date(row.ts) }) as WindowActivityEntity);
+  return rows.map((row) => ({ ...row, ts: parseSqliteUtcDateTime(row.ts) }) as WindowActivityEntity);
 }
 
 /** Loads the shared raw data once for every figure on the selected workday. */
 export async function loadRetrospectionWorkdayData(
-  date: Date | string
+  workdayRange: RetrospectionWorkdayRange
 ): Promise<RetrospectionWorkdayData> {
-  const { start } = getRetrospectionWorkdayRange(date);
   const [windowActivities, activeMinutes] = await Promise.all([
-    getWindowActivitiesForWorkday(date),
-    getActiveMinutesForWorkday(date)
+    getWindowActivitiesForWorkday(workdayRange),
+    getActiveMinutesForWorkday(workdayRange)
   ]);
 
-  return { activeMinutes, windowActivities, workdayStart: start };
+  return { activeMinutes, windowActivities, workdayStart: workdayRange.start };
 }

--- a/src/electron/electron/main/services/retrospection/RetrospectionWorkdayData.ts
+++ b/src/electron/electron/main/services/retrospection/RetrospectionWorkdayData.ts
@@ -35,6 +35,7 @@ export async function getActiveMinutesForWorkday(
 ): Promise<Set<number>> {
   const workdayStart = formatSqliteUtcDateTime(workdayRange.start);
   const workdayEnd = formatSqliteUtcDateTime(workdayRange.end);
+  // A local 04:00-to-04:00 workday spans 23 or 25 hours across a DST transition.
   const workdayMinuteCount = Math.round(
     (workdayRange.end.getTime() - workdayRange.start.getTime()) / 60_000
   );

--- a/src/electron/shared/retrospection/Workday.ts
+++ b/src/electron/shared/retrospection/Workday.ts
@@ -43,17 +43,25 @@ export function getDateFromWorkdayMinuteIndex(minuteIndex: number, workdayStart:
   return new Date(workdayStart.getTime() + minuteIndex * 60000);
 }
 
-/** Formats a local timestamp for SQLite `datetime(..., 'localtime')` comparison. */
-export function formatSqliteLocalDateTime(date: Date): string {
+/** Formats an instant as the UTC datetime format used by the SQLite tracker tables. */
+export function formatSqliteUtcDateTime(date: Date): string {
   const parts = [
-    date.getFullYear(),
-    `${date.getMonth() + 1}`.padStart(2, '0'),
-    `${date.getDate()}`.padStart(2, '0')
+    date.getUTCFullYear(),
+    `${date.getUTCMonth() + 1}`.padStart(2, '0'),
+    `${date.getUTCDate()}`.padStart(2, '0')
   ];
-  const time = [date.getHours(), date.getMinutes(), date.getSeconds()]
+  const time = [date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds()]
     .map((value) => `${value}`.padStart(2, '0'))
     .join(':');
   return `${parts.join('-')} ${time}`;
+}
+
+/** Parses the timezone-less UTC datetime strings persisted by TypeORM's SQLite driver. */
+export function parseSqliteUtcDateTime(value: Date | string): Date {
+  if (value instanceof Date) return value;
+
+  const timestamp = value.includes('T') ? value : value.replace(' ', 'T');
+  return new Date(/(?:Z|[+-]\d{2}:?\d{2})$/i.test(timestamp) ? timestamp : `${timestamp}Z`);
 }
 
 function floorToLocalHour(timestamp: number): number {
@@ -67,6 +75,17 @@ export function getRetrospectionTimelineBounds(
   selectedDay: Date | string,
   timestamps: Array<Date | number | string | null | undefined>
 ): RetrospectionTimelineBounds | null {
+  return getRetrospectionTimelineBoundsForRange(
+    getRetrospectionWorkdayRange(selectedDay),
+    timestamps
+  );
+}
+
+/** Computes timeline bounds from a workday range already resolved in the current UI timezone. */
+export function getRetrospectionTimelineBoundsForRange(
+  workdayRange: RetrospectionWorkdayRange,
+  timestamps: Array<Date | number | string | null | undefined>
+): RetrospectionTimelineBounds | null {
   const values = timestamps
     .map((timestamp) =>
       timestamp instanceof Date
@@ -76,9 +95,8 @@ export function getRetrospectionTimelineBounds(
           : timestamp
     )
     .filter((timestamp): timestamp is number => typeof timestamp === 'number' && Number.isFinite(timestamp));
-  const { start: workdayStartDate, end: workdayEndDate } = getRetrospectionWorkdayRange(selectedDay);
-  const workdayStart = workdayStartDate.getTime();
-  const workdayEnd = workdayEndDate.getTime();
+  const workdayStart = workdayRange.start.getTime();
+  const workdayEnd = workdayRange.end.getTime();
   const inRange = values.filter((timestamp) => timestamp >= workdayStart && timestamp < workdayEnd);
   if (!inRange.length) return null;
 

--- a/src/electron/shared/retrospection/Workday.ts
+++ b/src/electron/shared/retrospection/Workday.ts
@@ -40,6 +40,7 @@ export function getRetrospectionWorkdayRange(date: Date | string): Retrospection
   return { start, end };
 }
 
+/** Converts serialized IPC range boundaries to validated Date instances for internal services. */
 export function normalizeRetrospectionWorkdayRange(
   workdayRange: RetrospectionWorkdayRangeInput
 ): RetrospectionWorkdayRange {

--- a/src/electron/shared/retrospection/Workday.ts
+++ b/src/electron/shared/retrospection/Workday.ts
@@ -5,6 +5,11 @@ export interface RetrospectionWorkdayRange {
   end: Date;
 }
 
+export interface RetrospectionWorkdayRangeInput {
+  start: Date | string;
+  end: Date | string;
+}
+
 export interface RetrospectionTimelineBounds {
   start: number;
   end: number;
@@ -32,6 +37,25 @@ export function getRetrospectionWorkdayRange(date: Date | string): Retrospection
   );
   const end = new Date(start);
   end.setDate(end.getDate() + 1);
+  return { start, end };
+}
+
+export function normalizeRetrospectionWorkdayRange(
+  workdayRange: RetrospectionWorkdayRangeInput
+): RetrospectionWorkdayRange {
+  const start =
+    workdayRange.start instanceof Date
+      ? new Date(workdayRange.start.getTime())
+      : new Date(workdayRange.start);
+  const end =
+    workdayRange.end instanceof Date
+      ? new Date(workdayRange.end.getTime())
+      : new Date(workdayRange.end);
+
+  if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime()) || end <= start) {
+    throw new TypeError('Invalid retrospection workday range');
+  }
+
   return { start, end };
 }
 

--- a/src/electron/src/utils/Commands.ts
+++ b/src/electron/src/utils/Commands.ts
@@ -13,6 +13,7 @@ import type {
   DailySurveySamplingType,
   ExperienceSamplingAnswerType
 } from '../../shared/StudyConfiguration';
+import type { RetrospectionWorkdayRange } from '../../shared/retrospection/Workday';
 import type { ActiveHoursInsight, ActivitySessions, TimeActive } from './retrospection/types';
 
 type Commands = {
@@ -62,13 +63,13 @@ type Commands = {
   startAllTrackers: () => void;
   triggerPermissionCheckAccessibility: (prompt: boolean) => boolean;
   triggerPermissionCheckScreenRecording: () => boolean;
-  retrospectionGetActiveHours: (date: Date) => Promise<ActiveHoursInsight>;
-  retrospectionGetActivities: (date: Date) => Promise<ActivitySessions[]>;
-  retrospectionLoadLongestTimeActive: (date: Date) => Promise<TimeActive | undefined>;
-  retrospectionGetTopThreeMostActiveApps: (date: Date) => Promise<ActivitySessions[]>;
-  retrospectionGetTopThreeWebsites: (date: Date) => Promise<ActivitySessions[]>;
-  retrospectionGetTopThreeWindowTitles: (date: Date) => Promise<ActivitySessions[]>;
-  retrospectionGetSelfReports: (date: Date) => Promise<ExperienceSamplingDto[]>;
+  retrospectionGetActiveHours: (workdayRange: RetrospectionWorkdayRange) => Promise<ActiveHoursInsight>;
+  retrospectionGetActivities: (workdayRange: RetrospectionWorkdayRange) => Promise<ActivitySessions[]>;
+  retrospectionLoadLongestTimeActive: (workdayRange: RetrospectionWorkdayRange) => Promise<TimeActive | undefined>;
+  retrospectionGetTopThreeMostActiveApps: (workdayRange: RetrospectionWorkdayRange) => Promise<ActivitySessions[]>;
+  retrospectionGetTopThreeWebsites: (workdayRange: RetrospectionWorkdayRange) => Promise<ActivitySessions[]>;
+  retrospectionGetTopThreeWindowTitles: (workdayRange: RetrospectionWorkdayRange) => Promise<ActivitySessions[]>;
+  retrospectionGetSelfReports: (workdayRange: RetrospectionWorkdayRange) => Promise<ExperienceSamplingDto[]>;
   openRetrospection: () => Promise<void>;
   closeRetrospectionWindow: () => void;
   createDailySurveyResponses: (

--- a/src/electron/src/views/RetrospectionView.vue
+++ b/src/electron/src/views/RetrospectionView.vue
@@ -41,7 +41,6 @@ const selfReports = ref<ExperienceSamplingDto[]>([]);
 const ACTIVITY_BREAKDOWN_COVERAGE = 0.9;
 const ACTIVITY_BREAKDOWN_MAX_ITEMS = 6;
 const EXCLUDED_ACTIVITY_BREAKDOWN_GROUPS = new Set(['Other', 'Unknown']);
-const TIMEZONE_CHECK_INTERVAL_MS = 1_000;
 const experienceSamplingEnabled = studyConfig.trackers.experienceSamplingTracker.enabled;
 const isWindowActivityTrackerEnabled = studyConfig.trackers.windowActivityTracker.enabled;
 const selectedWorkdayRange = computed(() => {
@@ -244,19 +243,12 @@ const activityBreakdownStyle = computed((): CSSProperties => {
 onMounted(async () => {
   window.addEventListener('focus', refreshForTimezoneChange);
   document.addEventListener('visibilitychange', refreshForTimezoneChange);
-  // macOS can apply a timezone change after the focus event that follows a settings change.
-  timezoneCheckInterval = window.setInterval(() => {
-    void refreshForTimezoneChange();
-  }, TIMEZONE_CHECK_INTERVAL_MS);
   await loadData();
 });
 
 onBeforeUnmount(() => {
   window.removeEventListener('focus', refreshForTimezoneChange);
   document.removeEventListener('visibilitychange', refreshForTimezoneChange);
-  if (timezoneCheckInterval !== undefined) {
-    window.clearInterval(timezoneCheckInterval);
-  }
 });
 
 // The renderer resolves the local 04:00-to-04:00 workday once and sends the resulting UTC
@@ -477,7 +469,6 @@ async function navigateToToday() {
 
 let currentTimezoneKey = getTimezoneKey();
 let currentLocalDay = formatDateInputValue(new Date());
-let timezoneCheckInterval: number | undefined;
 
 function getTimezoneKey(): string {
   return `${Intl.DateTimeFormat().resolvedOptions().timeZone}|${new Date().getTimezoneOffset()}`;

--- a/src/electron/src/views/RetrospectionView.vue
+++ b/src/electron/src/views/RetrospectionView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, type CSSProperties } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, type CSSProperties } from 'vue';
 import {
   Activity,
   Color,
@@ -29,6 +29,7 @@ import {
 const typedIpcRenderer = window.ipcRenderer;
 const isLoading = ref(false);
 const selectedDay = ref(formatDateInputValue(new Date()));
+const timezoneVersion = ref(0);
 const allWindowActivities = ref<ActivitySessions[]>([]);
 const chartDataWindowActivities = ref<ChartDataPoint[]>();
 const longestTimeActive = ref<TimeActive | undefined>(undefined);
@@ -40,9 +41,13 @@ const selfReports = ref<ExperienceSamplingDto[]>([]);
 const ACTIVITY_BREAKDOWN_COVERAGE = 0.9;
 const ACTIVITY_BREAKDOWN_MAX_ITEMS = 6;
 const EXCLUDED_ACTIVITY_BREAKDOWN_GROUPS = new Set(['Other', 'Unknown']);
+const TIMEZONE_CHECK_INTERVAL_MS = 1_000;
 const experienceSamplingEnabled = studyConfig.trackers.experienceSamplingTracker.enabled;
 const isWindowActivityTrackerEnabled = studyConfig.trackers.windowActivityTracker.enabled;
-const selectedWorkdayRange = computed(() => getRetrospectionWorkdayRange(selectedDay.value));
+const selectedWorkdayRange = computed(() => {
+  void timezoneVersion.value;
+  return getRetrospectionWorkdayRange(selectedDay.value);
+});
 
 interface ActivityBreakdownDataPoint extends PieChartDataPoint {
   percentage: number;
@@ -237,7 +242,21 @@ const activityBreakdownStyle = computed((): CSSProperties => {
 });
 
 onMounted(async () => {
+  window.addEventListener('focus', refreshForTimezoneChange);
+  document.addEventListener('visibilitychange', refreshForTimezoneChange);
+  // macOS can apply a timezone change after the focus event that follows a settings change.
+  timezoneCheckInterval = window.setInterval(() => {
+    void refreshForTimezoneChange();
+  }, TIMEZONE_CHECK_INTERVAL_MS);
   await loadData();
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('focus', refreshForTimezoneChange);
+  document.removeEventListener('visibilitychange', refreshForTimezoneChange);
+  if (timezoneCheckInterval !== undefined) {
+    window.clearInterval(timezoneCheckInterval);
+  }
 });
 
 // The renderer resolves the local 04:00-to-04:00 workday once and sends the resulting UTC
@@ -453,6 +472,30 @@ async function navigateToNextDay() {
 async function navigateToToday() {
   if (isToday.value) return;
   selectedDay.value = formatDateInputValue(new Date());
+  await loadData();
+}
+
+let currentTimezoneKey = getTimezoneKey();
+let currentLocalDay = formatDateInputValue(new Date());
+let timezoneCheckInterval: number | undefined;
+
+function getTimezoneKey(): string {
+  return `${Intl.DateTimeFormat().resolvedOptions().timeZone}|${new Date().getTimezoneOffset()}`;
+}
+
+async function refreshForTimezoneChange(): Promise<void> {
+  if (document.visibilityState === 'hidden') return;
+
+  const nextTimezoneKey = getTimezoneKey();
+  if (nextTimezoneKey === currentTimezoneKey) return;
+
+  const wasShowingToday = selectedDay.value === currentLocalDay;
+  currentTimezoneKey = nextTimezoneKey;
+  currentLocalDay = formatDateInputValue(new Date());
+  timezoneVersion.value++;
+  if (wasShowingToday) {
+    selectedDay.value = currentLocalDay;
+  }
   await loadData();
 }
 

--- a/src/electron/src/views/RetrospectionView.vue
+++ b/src/electron/src/views/RetrospectionView.vue
@@ -20,11 +20,15 @@ import StackedBarChart from '../components/StackedBarChart.vue';
 import SelfReportTimelineChart from '../components/SelfReportTimelineChart.vue';
 import type ExperienceSamplingDto from '../../shared/dto/ExperienceSamplingDto';
 import studyConfig from '../../shared/study.config';
-import { getRetrospectionTimelineBounds } from '../../shared/retrospection/Workday';
+import {
+  getRetrospectionTimelineBoundsForRange,
+  getRetrospectionWorkdayRange,
+  type RetrospectionWorkdayRange
+} from '../../shared/retrospection/Workday';
 
 const typedIpcRenderer = window.ipcRenderer;
 const isLoading = ref(false);
-const selectedDay = ref(new Date());
+const selectedDay = ref(formatDateInputValue(new Date()));
 const allWindowActivities = ref<ActivitySessions[]>([]);
 const chartDataWindowActivities = ref<ChartDataPoint[]>();
 const longestTimeActive = ref<TimeActive | undefined>(undefined);
@@ -38,6 +42,7 @@ const ACTIVITY_BREAKDOWN_MAX_ITEMS = 6;
 const EXCLUDED_ACTIVITY_BREAKDOWN_GROUPS = new Set(['Other', 'Unknown']);
 const experienceSamplingEnabled = studyConfig.trackers.experienceSamplingTracker.enabled;
 const isWindowActivityTrackerEnabled = studyConfig.trackers.windowActivityTracker.enabled;
+const selectedWorkdayRange = computed(() => getRetrospectionWorkdayRange(selectedDay.value));
 
 interface ActivityBreakdownDataPoint extends PieChartDataPoint {
   percentage: number;
@@ -107,7 +112,7 @@ const latestSelfReport = computed((): number => {
 });
 
 const timelineStartDate = computed((): number => {
-  const bounds = getRetrospectionTimelineBounds(selectedDay.value, [
+  const bounds = getRetrospectionTimelineBoundsForRange(selectedWorkdayRange.value, [
     ...(chartDataWindowActivities.value ?? []).flatMap((point) => [point.start, point.end]),
     ...selfReports.value.map((report) => report.promptedAt)
   ]);
@@ -120,7 +125,7 @@ const timelineStartDate = computed((): number => {
 });
 
 const timelineEndDate = computed((): number => {
-  const bounds = getRetrospectionTimelineBounds(selectedDay.value, [
+  const bounds = getRetrospectionTimelineBoundsForRange(selectedWorkdayRange.value, [
     ...(chartDataWindowActivities.value ?? []).flatMap((point) => [point.start, point.end]),
     ...selfReports.value.map((report) => report.promptedAt)
   ]);
@@ -235,19 +240,19 @@ onMounted(async () => {
   await loadData();
 });
 
-// selectedDay is a calendar date; the main process resolves it to the 04:00-to-04:00 local
-// workday (getRetrospectionWorkdayRange), so work before 04:00 belongs to the previous day.
-// Every data query and visualization for a day must apply that same range uniformly.
+// The renderer resolves the local 04:00-to-04:00 workday once and sends the resulting UTC
+// boundaries to the main process, so an already-running main process cannot use a stale timezone.
 async function loadData() {
   isLoading.value = true;
+  const workdayRange = selectedWorkdayRange.value;
   try {
-    await loadActiveHours();
-    await loadLongestTimeActive();
-    await loadMostActiveApps();
-    await loadTopWebsites();
-    await loadTopWindowTitles();
-    await loadSelfReports();
-    await loadWindowActivities();
+    await loadActiveHours(workdayRange);
+    await loadLongestTimeActive(workdayRange);
+    await loadMostActiveApps(workdayRange);
+    await loadTopWebsites(workdayRange);
+    await loadTopWindowTitles(workdayRange);
+    await loadSelfReports(workdayRange);
+    await loadWindowActivities(workdayRange);
   } finally {
     isLoading.value = false;
   }
@@ -273,11 +278,11 @@ function windowActivitiesToChartData() {
   chartDataWindowActivities.value = dataPoints;
 }
 
-async function loadWindowActivities() {
+async function loadWindowActivities(workdayRange: RetrospectionWorkdayRange) {
   try {
     allWindowActivities.value = (await typedIpcRenderer.invoke(
       'retrospectionGetActivities',
-      selectedDay.value
+      workdayRange
     )) as ActivitySessions[];
     windowActivitiesToChartData();
   } catch (error) {
@@ -287,62 +292,62 @@ async function loadWindowActivities() {
   }
 }
 
-async function loadActiveHours() {
+async function loadActiveHours(workdayRange: RetrospectionWorkdayRange) {
   try {
     activeHoursInsight.value = (await typedIpcRenderer.invoke(
       'retrospectionGetActiveHours',
-      selectedDay.value
+      workdayRange
     )) as ActiveHoursInsight;
   } catch (error) {
     console.error('Error loading active hours', error);
   }
 }
 
-async function loadLongestTimeActive() {
+async function loadLongestTimeActive(workdayRange: RetrospectionWorkdayRange) {
   try {
     longestTimeActive.value = (await typedIpcRenderer.invoke(
       'retrospectionLoadLongestTimeActive',
-      selectedDay.value
+      workdayRange
     )) as TimeActive;
   } catch (error) {
     console.error('Error loading longest time active', error);
   }
 }
 
-async function loadMostActiveApps() {
+async function loadMostActiveApps(workdayRange: RetrospectionWorkdayRange) {
   try {
     topApps.value = (await typedIpcRenderer.invoke(
       'retrospectionGetTopThreeMostActiveApps',
-      selectedDay.value
+      workdayRange
     )) as ActivitySessions[];
   } catch (error) {
     console.error('Error loading most active apps', error);
   }
 }
 
-async function loadTopWebsites() {
+async function loadTopWebsites(workdayRange: RetrospectionWorkdayRange) {
   try {
     topWebsites.value = (await typedIpcRenderer.invoke(
       'retrospectionGetTopThreeWebsites',
-      selectedDay.value
+      workdayRange
     )) as ActivitySessions[];
   } catch (error) {
     console.error('Error loading top websites', error);
   }
 }
 
-async function loadTopWindowTitles() {
+async function loadTopWindowTitles(workdayRange: RetrospectionWorkdayRange) {
   try {
     topWindowTitles.value = (await typedIpcRenderer.invoke(
       'retrospectionGetTopThreeWindowTitles',
-      selectedDay.value
+      workdayRange
     )) as ActivitySessions[];
   } catch (error) {
     console.error('Error loading top window titles', error);
   }
 }
 
-async function loadSelfReports() {
+async function loadSelfReports(workdayRange: RetrospectionWorkdayRange) {
   if (!experienceSamplingEnabled) {
     selfReports.value = [];
     return;
@@ -350,7 +355,7 @@ async function loadSelfReports() {
   try {
     selfReports.value = (await typedIpcRenderer.invoke(
       'retrospectionGetSelfReports',
-      selectedDay.value
+      workdayRange
     )) as ExperienceSamplingDto[];
   } catch (error) {
     selfReports.value = [];
@@ -410,7 +415,7 @@ function getTopItemColor(item: ActivitySessions): string {
 async function handleDayChange(event: Event) {
   const value = (event.target as HTMLInputElement).value;
   if (!value) return;
-  selectedDay.value = parseDateInputValue(value);
+  selectedDay.value = value;
   await loadData();
 }
 
@@ -427,32 +432,27 @@ function formatDateInputValue(date: Date): string {
 }
 
 const isToday = computed(() => {
-  const today = new Date();
-  return (
-    selectedDay.value.getDate() === today.getDate() &&
-    selectedDay.value.getMonth() === today.getMonth() &&
-    selectedDay.value.getFullYear() === today.getFullYear()
-  );
+  return selectedDay.value === formatDateInputValue(new Date());
 });
 
 async function navigateToPreviousDay() {
-  const newDate = new Date(selectedDay.value);
+  const newDate = parseDateInputValue(selectedDay.value);
   newDate.setDate(newDate.getDate() - 1);
-  selectedDay.value = newDate;
+  selectedDay.value = formatDateInputValue(newDate);
   await loadData();
 }
 
 async function navigateToNextDay() {
   if (isToday.value) return;
-  const newDate = new Date(selectedDay.value);
+  const newDate = parseDateInputValue(selectedDay.value);
   newDate.setDate(newDate.getDate() + 1);
-  selectedDay.value = newDate;
+  selectedDay.value = formatDateInputValue(newDate);
   await loadData();
 }
 
 async function navigateToToday() {
   if (isToday.value) return;
-  selectedDay.value = new Date();
+  selectedDay.value = formatDateInputValue(new Date());
   await loadData();
 }
 
@@ -469,7 +469,8 @@ function getTimeString(date: Date | string | number): string {
   return `${hours}:${minutes}`;
 }
 
-function getDayLabel(date: Date): string {
+function getDayLabel(day: string): string {
+  const date = parseDateInputValue(day);
   const today = new Date();
   const yesterday = new Date();
   yesterday.setDate(yesterday.getDate() - 1);
@@ -533,7 +534,7 @@ function getDayLabel(date: Date): string {
         </button>
         <input
           type="date"
-          :value="formatDateInputValue(selectedDay)"
+          :value="selectedDay"
           :max="formatDateInputValue(new Date())"
           class="h-8 rounded border border-gray-300 bg-white px-2 text-gray-800 dark:border-neutral-600 dark:bg-neutral-700 dark:text-slate-200"
           style="min-width: 140px"
@@ -612,7 +613,7 @@ function getDayLabel(date: Date): string {
         </button>
         <input
           type="date"
-          :value="formatDateInputValue(selectedDay)"
+          :value="selectedDay"
           :max="formatDateInputValue(new Date())"
           class="h-8 rounded border border-gray-300 bg-white px-2 text-gray-800 dark:border-neutral-600 dark:bg-neutral-700 dark:text-slate-200"
           style="min-width: 140px"


### PR DESCRIPTION
# Retrospection: Handle Timezone Changes Correctly (Closes #571)

## Description

Fixes Retrospection showing the wrong calendar day or retaining stale timeline data after the system timezone changes.

Tracker timestamps were already stored in UTC. The problem was that the selected workday was resolved using the Electron main process timezone, which could remain stale after an operating-system timezone change. SQLite's `localtime` conversion then applied that stale timezone when querying the data.

The selected calendar day and its 04:00-to-04:00 workday are now resolved in the renderer's current local timezone. The resulting UTC boundaries are passed through IPC and used consistently for all Retrospection queries and timeline calculations.

### Changes Made

- Stores the selected Retrospection day as a local calendar date instead of a timezone-dependent `Date`
- Resolves the 04:00-to-04:00 workday in the renderer's current timezone
- Passes the resolved UTC start and end boundaries through the Retrospection IPC commands
- Queries UTC timestamps directly instead of relying on SQLite's process-local `localtime` conversion
- Interprets raw Window Activity and User Input timestamps as UTC
- Uses the same resolved workday range for timeline bounds and all dashboard sections
- Detects system timezone changes and reloads Retrospection data
- Moves the selected date to the new local day when Retrospection was displaying Today
- Keeps a manually selected historical calendar date selected while reloading it in the new timezone
- Updates the existing service tests for the new workday-range contract

Closes #571