### PR TITLE
[#41] Prevent Duplicate Retrospection Windows

### DIFF
--- a/src/electron/electron/ipc/IpcHandler.ts
+++ b/src/electron/electron/ipc/IpcHandler.ts
@@ -378,7 +378,7 @@ export class IpcHandler {
   }
 
   private async openRetrospection(): Promise<void> {
-    await this.windowService.createRetrospectionWindow();
+    await this.windowService.focusOrCreateRetrospectionWindow();
   }
 
   private closeRetrospectionWindow(): void {

--- a/src/electron/electron/main/services/SchedulingService.ts
+++ b/src/electron/electron/main/services/SchedulingService.ts
@@ -78,6 +78,6 @@ export class SchedulingService {
       return
     }
 
-    await this.windowService.createRetrospectionWindow()
+    await this.windowService.focusOrCreateRetrospectionWindow()
   }
 }

--- a/src/electron/electron/main/services/WindowService.ts
+++ b/src/electron/electron/main/services/WindowService.ts
@@ -344,7 +344,7 @@ export class WindowService {
     }
   }
 
-  public async createRetrospectionWindow() {
+  private async createRetrospectionWindow() {
     this.closeRetrospectionWindow()
 
     const __filename = fileURLToPath(import.meta.url)
@@ -650,7 +650,7 @@ export class WindowService {
         : []),
       {
         label: 'Retrospection',
-        click: () => this.createRetrospectionWindow(),
+        click: () => this.focusOrCreateRetrospectionWindow(),
         visible: studyConfig.enableRetrospection ?? true
       },
       {


### PR DESCRIPTION
# Retrospection: Prevent Duplicate Windows (Closes #41)

## Description

Prevents multiple Retrospection windows from being created when more than one open request occurs around the scheduled end-of-workday time.

Newer versions already included a `focusOrCreateRetrospectionWindow` method, but the automatic scheduler, renderer IPC, and tray menu still bypassed it and created a new window directly.

### Changes Made

- Uses the existing focus-or-create behavior for automatically scheduled Retrospection windows
- Uses the same behavior when opening Retrospection through IPC or the tray menu
- Focuses the existing Retrospection window instead of closing and recreating it
- Makes direct Retrospection window creation private so external callers cannot bypass the duplicate-window guard

Closes #41