### PR TITLE
[#589] Retrospection: Unify Time Displays

### DIFF
--- a/src/electron/src/components/RetrospectionTopItemsCard.vue
+++ b/src/electron/src/components/RetrospectionTopItemsCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { PropType } from 'vue';
 import { Activity, Color, type ActivitySessions } from '../utils/retrospection/types';
-import { getTailwindClassFromActivity } from '../utils/retrospection/utils';
+import { formatDuration, getTailwindClassFromActivity } from '../utils/retrospection/utils';
 
 defineProps({
   title: {
@@ -13,20 +13,6 @@ defineProps({
     required: true
   }
 });
-
-function renderCompactTime(ms: number): string {
-  const minutes = Math.round(ms / 60_000);
-  if (minutes < 1) {
-    return '< 1 min';
-  }
-  if (minutes < 60) {
-    return `${minutes} min`;
-  }
-
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
-  return remainingMinutes ? `${hours} hr ${remainingMinutes} min` : `${hours} hr`;
-}
 
 function getTopItemWidth(item: ActivitySessions, items: ActivitySessions[]): string {
   const maxDurationMs = Math.max(...items.map((topItem) => topItem.totalDurationMs), 1);
@@ -69,7 +55,7 @@ function getTopItemInitial(item: ActivitySessions): string {
             </span>
             <span class="top-item-label">{{ item.type }}</span>
           </span>
-          <span class="top-item-time">{{ renderCompactTime(item.totalDurationMs) }}</span>
+          <span class="top-item-time">{{ formatDuration(item.totalDurationMs) }}</span>
         </div>
         <div class="top-item-track">
           <div

--- a/src/electron/src/components/StackedBarChart.vue
+++ b/src/electron/src/components/StackedBarChart.vue
@@ -17,9 +17,9 @@ import { Color } from '../utils/retrospection/types';
 import {
   ACTIVITY_LABELS,
   escapeHtml,
+  formatDuration,
   getActivityGroupFromActivityName,
   getBarColorFromDataPoint,
-  msToReadableFormat,
   TW_CLASS_ACTIVITY_MAPPINGS
 } from '../utils/retrospection/utils';
 import { positionTooltipWithinViewport } from '../utils/tooltipPosition';
@@ -160,22 +160,8 @@ function renderTooltipDetailIcon(detail: TimelineHoverDetail): string {
   `;
 }
 
-function renderTooltipDuration(durationInMs: number): string {
-  const totalMinutes = Math.round(durationInMs / 60000);
-  if (totalMinutes < 1) {
-    return '< 1 min';
-  }
-  if (totalMinutes < 60) {
-    return `${totalMinutes} min`;
-  }
-
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  return minutes ? `${hours} h ${minutes} min` : `${hours} h`;
-}
-
 function renderTooltipDetail(detail: TimelineHoverDetail): string {
-  const duration = renderTooltipDuration(detail.durationMs);
+  const duration = formatDuration(detail.durationMs);
   const title = escapeHtml(detail.title);
   const tooltipTitle = escapeHtml(detail.tooltipTitle || detail.title);
   const appName = detail.appName ? escapeHtml(detail.appName) : '';
@@ -286,7 +272,7 @@ function buildChart() {
     })
     .on('mousemove', function (this: SVGRectElement, event: MouseEvent, d: unknown) {
       const dataPoint = d as ChartDataPoint;
-      const duration = renderTooltipDuration(dataPoint.end.getTime() - dataPoint.start.getTime());
+      const duration = formatDuration(dataPoint.end.getTime() - dataPoint.start.getTime());
 
       const barBoundingRect = this.getBoundingClientRect();
 
@@ -342,7 +328,7 @@ function getLegendDataForWindowActivity(): LegendDataPoint[] {
   activeTaskTotalTimeSpentPerActivityGroup.forEach((item) => {
     const colorKey = TW_CLASS_ACTIVITY_MAPPINGS[item.activityGroup] as keyof typeof Color;
     legendData.push({
-      text: `${ACTIVITY_LABELS[item.activityGroup] || 'Other'} (${msToReadableFormat(item.totalTime, false, false)})`,
+      text: `${ACTIVITY_LABELS[item.activityGroup] || 'Other'} (${formatDuration(item.totalTime)})`,
       color: Color[colorKey],
       key: item.activityGroup
     });

--- a/src/electron/src/utils/retrospection/__tests__/utils.test.ts
+++ b/src/electron/src/utils/retrospection/__tests__/utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from '@jest/globals';
+import { formatDuration } from '../utils';
+
+describe('formatDuration', () => {
+  test.each([
+    [0, '0 mins'],
+    [20_000, '< 1 min'],
+    [60_000, '1 min'],
+    [24 * 60_000, '24 mins'],
+    [60 * 60_000, '1 hr'],
+    [61 * 60_000, '1 hr 1 min'],
+    [84 * 60_000, '1 hr 24 mins'],
+    [120 * 60_000, '2 hrs']
+  ])('formats %s milliseconds as %s', (durationInMs, expected) => {
+    expect(formatDuration(durationInMs)).toBe(expected);
+  });
+});

--- a/src/electron/src/utils/retrospection/utils.ts
+++ b/src/electron/src/utils/retrospection/utils.ts
@@ -1,32 +1,24 @@
 import { Color, Activity } from './types';
 
-export function msToReadableFormat(
-  durationInMs: number,
-  flashColon: boolean = false,
-  showSeconds: boolean = false
-): string {
-  const flash: ':' | ' ' = flashColon ? (Math.floor(Date.now() / 1000) % 2 === 0 ? ':' : ' ') : ':';
-
-  const hours = Math.floor(durationInMs / (1000 * 60 * 60));
-  const minutes = Math.floor((durationInMs % (1000 * 60 * 60)) / (1000 * 60));
-  const seconds = Math.floor((durationInMs % (1000 * 60)) / 1000);
-
-  const formattedHours = String(hours).padStart(2, '0');
-  const formattedMinutes = String(minutes).padStart(2, '0');
-  const formattedSeconds = String(seconds).padStart(2, '0');
-
-  let formatWithoutSeconds = `${formattedHours}${flash}${formattedMinutes}`;
-  if (formatWithoutSeconds === '00:00') {
-    formatWithoutSeconds = '< 00:01';
+export function formatDuration(durationInMs: number): string {
+  if (!Number.isFinite(durationInMs) || durationInMs <= 0) {
+    return '0 mins';
   }
 
-  return showSeconds
-    ? `${formattedHours}${flash}${formattedMinutes}${flash}${formattedSeconds}`
-    : `${formatWithoutSeconds}`;
-}
+  const totalMinutes = Math.round(durationInMs / 60_000);
+  if (totalMinutes < 1) {
+    return '< 1 min';
+  }
+  if (totalMinutes < 60) {
+    return `${totalMinutes} ${totalMinutes === 1 ? 'min' : 'mins'}`;
+  }
 
-export function msToDecimalHours(durationInMs: number): string {
-  return `${(durationInMs / 3600000).toFixed(1)} hours`
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  const formattedHours = `${hours} ${hours === 1 ? 'hr' : 'hrs'}`;
+  return minutes === 0
+    ? formattedHours
+    : `${formattedHours} ${minutes} ${minutes === 1 ? 'min' : 'mins'}`;
 }
 
 const ACTIVITY_GROUPS: Record<string, Activity[]> = {

--- a/src/electron/src/views/RetrospectionView.vue
+++ b/src/electron/src/views/RetrospectionView.vue
@@ -13,8 +13,8 @@ import {
 } from '../utils/retrospection/types';
 import {
   ACTIVITY_LABELS,
+  formatDuration,
   getActivityGroupFromActivityName,
-  msToDecimalHours,
   getTailwindClassFromActivity
 } from '../utils/retrospection/utils';
 import StackedBarChart from '../components/StackedBarChart.vue';
@@ -374,44 +374,6 @@ function hasSectionLoadError(section: RetrospectionDataSection): boolean {
   return loadErrors.value.includes(section);
 }
 
-function msToMinutes(ms: number): number {
-  return Math.round(ms / 60000);
-}
-
-function renderTime(ms: number): string {
-  let minutes = msToMinutes(ms);
-  if (minutes < 60) {
-    return `${minutes} minutes`;
-  }
-
-  const hours = Math.floor(minutes / 60);
-  minutes = minutes % 60;
-  if (minutes === 0) {
-    if (hours === 1) {
-      return `${hours} hour`;
-    } else {
-      return `${hours} hours`;
-    }
-  } else {
-    const fractionalHours = Math.round((minutes / 60) * 10) / 10;
-    return `${hours + fractionalHours} hours`;
-  }
-}
-
-function renderCompactTime(ms: number): string {
-  const minutes = msToMinutes(ms);
-  if (minutes < 1) {
-    return '< 1 min';
-  }
-  if (minutes < 60) {
-    return `${minutes} min`;
-  }
-
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
-  return remainingMinutes ? `${hours} hr ${remainingMinutes} min` : `${hours} hr`;
-}
-
 async function handleDayChange(event: Event) {
   const value = (event.target as HTMLInputElement).value;
   if (!value) return;
@@ -723,7 +685,7 @@ function getDayLabel(day: string): string {
             <h2 class="primary-blue font-bold leading-4">Longest active period</h2>
             <p class="mt-2">
               Your longest active streak was
-              <b>{{ renderTime(longestTimeActive!.duration * 60000) }}</b> (between
+              <b>{{ formatDuration(longestTimeActive!.duration * 60000) }}</b> (between
               {{ getTimeString(longestTimeActive!.from) }} and
               {{ getTimeString(longestTimeActive!.to) }}).
             </p>
@@ -741,14 +703,14 @@ function getDayLabel(day: string): string {
               <div>
                 <dt class="inline">Active on the computer:</dt>
                 <dd class="ml-1 inline">
-                  <b>{{ msToDecimalHours(activeHoursInsight?.activeDurationMs ?? 0) }}</b>
+                  <b>{{ formatDuration(activeHoursInsight?.activeDurationMs ?? 0) }}</b>
                 </dd>
               </div>
               <div v-if="hasActivityData">
                 <dt class="inline">Spanning work:</dt>
                 <dd class="ml-1 inline">
                   <b>{{
-                    msToDecimalHours(latestUserComputerActivity - earliestUserComputerActivity)
+                    formatDuration(latestUserComputerActivity - earliestUserComputerActivity)
                   }}</b>
                   (between {{ getTimeString(earliestUserComputerActivity) }} and
                   {{ getTimeString(latestUserComputerActivity) }})
@@ -771,7 +733,7 @@ function getDayLabel(day: string): string {
                 <li
                   v-for="activity in activityBreakdownData"
                   :key="activity.type"
-                  :title="`${activity.name}: ${renderCompactTime(activity.value)}`"
+                  :title="`${activity.name}: ${formatDuration(activity.value)}`"
                 >
                   <span class="activity-breakdown-label">
                     <span
@@ -781,7 +743,7 @@ function getDayLabel(day: string): string {
                     <span class="activity-breakdown-name">{{ activity.name }}</span>
                   </span>
                   <span class="activity-breakdown-time text-slate-700 dark:!text-slate-100">{{
-                    renderCompactTime(activity.value)
+                    formatDuration(activity.value)
                   }}</span>
                 </li>
               </ol>


### PR DESCRIPTION
# Retrospection: Unify Time Displays (Closes #589)

## Description

Unifies elapsed time formatting throughout Retrospection. Decimal-hour and clock-style durations are replaced with explicit hour-and-minute values such as `1 hr 24 mins`.

### Changes Made

- Added a shared formatter for elapsed durations
- Updated the Activities over time legend and hover details
- Updated longest active period, active hours, and spanning work
- Updated Activity Breakdown durations
- Updated Top apps, Top websites, and Top window titles
- Preserved clock times used for timestamps, ranges, and timeline axes
- Added tests for minute and hour formatting boundaries

## Screenshots

| Unified Retrospection time displays |
|:-:|
| <img width="1232" height="962" alt="Screenshot 2026-09-03 at 13 30 00" src="https://github.com/user-attachments/assets/2733c4d6-fe50-474f-906e-6b481169b532" /> |

Closes #589