### PR TITLE
Fix SchedulingService jobs silently dying after macOS sleep/wake

### DIFF
--- a/src/electron/electron/main/__tests__/SchedulingService.test.ts
+++ b/src/electron/electron/main/__tests__/SchedulingService.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, expect, jest, test } from '@jest/globals';
+import type { WorkHoursDto } from '../../../shared/dto/WorkHoursDto';
+
+const cancelMock = jest.fn();
+const scheduleJobMock = jest.fn(() => ({
+  cancel: cancelMock,
+  nextInvocation: () => new Date('2026-01-01T00:00:00Z')
+}));
+
+jest.unstable_mockModule('node-schedule', () => ({
+  scheduleJob: scheduleJobMock
+}));
+
+jest.unstable_mockModule('../entities/Settings', () => ({
+  Settings: { findOne: jest.fn() }
+}));
+
+jest.unstable_mockModule('../../../shared/study.config', () => ({
+  default: { enableRetrospection: true }
+}));
+
+jest.unstable_mockModule('../../config/Logger', () => ({
+  getMainLogger: () => ({ info: jest.fn(), debug: jest.fn(), error: jest.fn(), warn: jest.fn() }),
+  default: () => ({ info: jest.fn(), debug: jest.fn(), error: jest.fn(), warn: jest.fn() })
+}));
+
+const { SchedulingService } = await import('../services/SchedulingService');
+
+// Only Monday is a working day, so exactly one retrospection job (+ the 4am
+// cleanup job) is created per (re)schedule.
+const workSchedule: WorkHoursDto = {
+  monday: { isWorking: true, startTime: '09:00', endTime: '18:00' },
+  tuesday: { isWorking: false, startTime: '09:00', endTime: '18:00' },
+  wednesday: { isWorking: false, startTime: '09:00', endTime: '18:00' },
+  thursday: { isWorking: false, startTime: '09:00', endTime: '18:00' },
+  friday: { isWorking: false, startTime: '09:00', endTime: '18:00' },
+  saturday: { isWorking: false, startTime: '09:00', endTime: '18:00' },
+  sunday: { isWorking: false, startTime: '09:00', endTime: '18:00' }
+};
+
+const windowService = {
+  closeRetrospectionWindow: jest.fn(),
+  focusOrCreateRetrospectionWindow: jest.fn()
+};
+
+beforeEach(() => {
+  scheduleJobMock.mockClear();
+  cancelMock.mockClear();
+});
+
+test('resume() cancels the previous jobs and recreates them', () => {
+  const service = new SchedulingService(windowService as never, workSchedule);
+
+  // 1 retrospection job (Monday) + 1 cleanup job created on construction.
+  expect(scheduleJobMock).toHaveBeenCalledTimes(2);
+  expect(cancelMock).not.toHaveBeenCalled();
+
+  service.resume();
+
+  // The pre-sleep jobs must be torn down explicitly...
+  expect(cancelMock).toHaveBeenCalledTimes(2);
+  // ...and fresh node-schedule jobs created in their place, otherwise the
+  // service would be left with dead node-schedule timers after the OS wakes
+  // (node-schedule/node-schedule#13).
+  expect(scheduleJobMock).toHaveBeenCalledTimes(4);
+});
+
+test('resume() is safe to call repeatedly, e.g. across several sleep/wake cycles', () => {
+  const service = new SchedulingService(windowService as never, workSchedule);
+
+  service.resume();
+  service.resume();
+  service.resume();
+
+  // constructor (2) + 3 resumes (2 each) = 8
+  expect(scheduleJobMock).toHaveBeenCalledTimes(8);
+  expect(cancelMock).toHaveBeenCalledTimes(6);
+});

--- a/src/electron/electron/main/index.ts
+++ b/src/electron/electron/main/index.ts
@@ -41,6 +41,7 @@ const windowService: WindowService = new WindowService(appUpdaterService);
 const experienceSamplingService: ExperienceSamplingService = new ExperienceSamplingService();
 const trackers: TrackerService = new TrackerService(studyConfig.trackers, windowService, workScheduleService);
 const ipcHandler: IpcHandler = new IpcHandler(windowService, trackers, experienceSamplingService, workScheduleService);
+let schedulingService: SchedulingService | undefined;
 
 // Disable GPU Acceleration for Windows 7
 if (release().startsWith('6.1')) {
@@ -159,7 +160,7 @@ app.whenReady().then(async () => {
 
     if (studyConfig.enableRetrospection ?? true) {
       const workSchedule = await workScheduleService.getWorkSchedule();
-      const schedulingService = new SchedulingService(windowService, workSchedule);
+      schedulingService = new SchedulingService(windowService, workSchedule);
       ipcHandler.setSchedulingService(schedulingService);
     }
 
@@ -260,6 +261,10 @@ app.whenReady().then(async () => {
       });
       powerMonitor.on('resume', async (): Promise<void> => {
         LOG.debug('The system is resuming');
+        // SchedulingService isn't a Tracker, so it isn't covered by resumeAllTrackers();
+        // its node-schedule jobs need to be explicitly recreated after sleep (see
+        // https://github.com/node-schedule/node-schedule/issues/13).
+        schedulingService?.resume();
         await Promise.all([
           trackers.resumeAllTrackers(),
           UsageDataService.createNewUsageDataEvent(UsageDataEventType.SystemResume)

--- a/src/electron/electron/main/services/SchedulingService.ts
+++ b/src/electron/electron/main/services/SchedulingService.ts
@@ -9,21 +9,39 @@ const LOG = getMainLogger('SchedulingService')
 
 export class SchedulingService {
   private retrospectionJobs: schedule.Job[] = []
+  private cleanupJob: schedule.Job | undefined
   private readonly windowService: WindowService
+  private workSchedule: WorkHoursDto
 
   constructor(windowService: WindowService, workSchedule: WorkHoursDto) {
     this.windowService = windowService
+    this.workSchedule = workSchedule
     LOG.info('Initializing SchedulingService with work schedule')
     this.updateRetrospectionJobs(workSchedule)
+    this.scheduleCleanupJob()
+  }
 
+  // node-schedule's timers can silently stop firing after the system wakes from
+  // sleep (see https://github.com/node-schedule/node-schedule/issues/13). Since
+  // this service isn't a Tracker resumed via TrackerService, main/index.ts calls
+  // this explicitly on powerMonitor's 'resume' event to recreate the jobs.
+  public resume(): void {
+    LOG.info('Resuming SchedulingService: recreating scheduled jobs')
+    this.updateRetrospectionJobs(this.workSchedule)
+    this.scheduleCleanupJob()
+  }
+
+  private scheduleCleanupJob(): void {
+    this.cleanupJob?.cancel()
     // cleanup job daily at 4am
-    schedule.scheduleJob('0 4 * * *', async (): Promise<void> => {
+    this.cleanupJob = schedule.scheduleJob('0 4 * * *', async (): Promise<void> => {
       LOG.info('Running 4am cleanup: closing retrospection window')
       this.windowService.closeRetrospectionWindow()
     })
   }
 
   public updateRetrospectionJobs(workSchedule: WorkHoursDto): void {
+    this.workSchedule = workSchedule
     // cancel existing retrospection jobs
     if (this.retrospectionJobs.length > 0) {
       this.retrospectionJobs.forEach(j => j.cancel())


### PR DESCRIPTION
Closes #596

## Description

`SchedulingService`'s `node-schedule` cron jobs (retrospection windows, 4am cleanup) were never recreated after the OS resumes from sleep, since `SchedulingService` isn't a `Tracker` covered by `TrackerService.resumeAllTrackers()`. `node-schedule` is known to silently stop firing recurring jobs forever after a single sleep/wake cycle, with no error and the host process staying alive ([node-schedule/node-schedule#13](https://github.com/node-schedule/node-schedule/issues/13)). See #596 for full logs/analysis from a real occurrence.

`ExperienceSamplingTracker` already works around this by recreating its own `node-schedule` job in `resume()`. This PR applies the same pattern to `SchedulingService`.

## Changes

- `SchedulingService`: tracks the current work schedule and the cleanup job, adds a `resume()` that cancels and recreates both the retrospection jobs and the cleanup job.
- `main/index.ts`: hoists `schedulingService` so it's reachable from the `powerMonitor.on('resume', ...)` handler, and calls `schedulingService?.resume()` there.
- Adds `SchedulingService.test.ts`: constructs the service, calls `resume()`, and asserts the pre-sleep jobs are cancelled and fresh ones created. Verified this test fails against the pre-fix code (`service.resume is not a function`) and passes against the fix.

## Test plan

- [x] `vue-tsc --noEmit` passes
- [x] `npm test` — 8 suites / 77 tests pass (75 pre-existing + 2 new)
- [x] New test confirmed to fail against the pre-fix `SchedulingService.ts` and pass against the fix
- [x] `npm run build:mac:arm64` completes successfully (Vite build, Electron main/preload bundling, native module rebuild, packaged into signed `.app`/`.zip`/`.dmg`)
- [ ] Manual verification of a real sleep/wake cycle on a running build (not done here, since sleeping the build machine wasn't practical in this session)
